### PR TITLE
feat: add fullscreen 360° panorama viewer page

### DIFF
--- a/panorama-viewer.html
+++ b/panorama-viewer.html
@@ -15,12 +15,14 @@
       background: #000;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       color: #fff;
+      overscroll-behavior: none;
     }
 
     #app {
       position: fixed;
       inset: 0;
       background: #000;
+      touch-action: none;
     }
 
     .toolbar {
@@ -102,7 +104,7 @@
   <div class="toolbar">
     <label class="upload-btn" for="fileInput">上传全景图</label>
     <input id="fileInput" type="file" accept="image/*" />
-    <span class="tips">拖拽旋转 · 滚轮缩放（建议 2:1 equirectangular）</span>
+    <span class="tips">拖拽/单指旋转 · 滚轮/双指缩放（建议 2:1 equirectangular）</span>
   </div>
 
   <div id="placeholder" class="placeholder">
@@ -146,6 +148,9 @@
     controls.zoomSpeed = 0.9;
     controls.minDistance = 0.2;
     controls.maxDistance = 1;
+    controls.enableZoom = true;
+    controls.touches.ONE = THREE.TOUCH.ROTATE;
+    controls.touches.TWO = THREE.TOUCH.DOLLY_ROTATE;
 
     const geometry = new THREE.SphereGeometry(500, 96, 64);
     geometry.scale(-1, 1, 1);
@@ -221,6 +226,11 @@
       renderer.render(scene, camera);
       requestAnimationFrame(animate);
     }
+
+    // iOS/Safari 上首次触摸时确保控件接管手势，避免页面滚动/回弹影响体验
+    renderer.domElement.addEventListener('touchmove', (event) => {
+      event.preventDefault();
+    }, { passive: false });
 
     animate();
   </script>

--- a/panorama-viewer.html
+++ b/panorama-viewer.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>360° 全景查看器</title>
+  <style>
+    :root { color-scheme: dark; }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: #000;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      color: #fff;
+    }
+
+    #app {
+      position: fixed;
+      inset: 0;
+      background: #000;
+    }
+
+    .toolbar {
+      position: fixed;
+      top: 16px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 20;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      border-radius: 12px;
+      background: rgba(0, 0, 0, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+
+    .upload-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 8px 12px;
+      border-radius: 8px;
+      background: #2e7bff;
+      color: #fff;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 600;
+      border: none;
+      transition: transform 0.15s ease, background 0.2s ease;
+    }
+
+    .upload-btn:hover { background: #4a8dff; }
+    .upload-btn:active { transform: translateY(1px); }
+
+    #fileInput { display: none; }
+
+    .tips {
+      font-size: 13px;
+      line-height: 1.4;
+      color: rgba(255, 255, 255, 0.85);
+      white-space: nowrap;
+    }
+
+    .toast {
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      z-index: 20;
+      background: rgba(255, 80, 80, 0.9);
+      color: #fff;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      padding: 8px 12px;
+      border-radius: 8px;
+      font-size: 13px;
+      display: none;
+    }
+
+    .placeholder {
+      position: fixed;
+      inset: 0;
+      z-index: 5;
+      display: grid;
+      place-items: center;
+      text-align: center;
+      color: rgba(255, 255, 255, 0.75);
+      font-size: 15px;
+      padding: 24px;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+
+  <div class="toolbar">
+    <label class="upload-btn" for="fileInput">上传全景图</label>
+    <input id="fileInput" type="file" accept="image/*" />
+    <span class="tips">拖拽旋转 · 滚轮缩放（建议 2:1 equirectangular）</span>
+  </div>
+
+  <div id="placeholder" class="placeholder">
+    请选择一张 2:1 比例的 equirectangular 全景图开始查看
+  </div>
+
+  <div id="toast" class="toast" role="alert"></div>
+
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.166.1/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.166.1/examples/jsm/"
+      }
+    }
+  </script>
+
+  <script type="module">
+    import * as THREE from 'three';
+    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+    const container = document.getElementById('app');
+    const fileInput = document.getElementById('fileInput');
+    const placeholder = document.getElementById('placeholder');
+    const toast = document.getElementById('toast');
+
+    const scene = new THREE.Scene();
+
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 2000);
+    camera.position.set(0, 0, 0.1);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    container.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enablePan = false;
+    controls.enableDamping = true;
+    controls.rotateSpeed = -0.28;
+    controls.zoomSpeed = 0.9;
+    controls.minDistance = 0.2;
+    controls.maxDistance = 1;
+
+    const geometry = new THREE.SphereGeometry(500, 96, 64);
+    geometry.scale(-1, 1, 1);
+
+    let material = new THREE.MeshBasicMaterial({ color: 0x111111 });
+    const sphere = new THREE.Mesh(geometry, material);
+    scene.add(sphere);
+
+    const textureLoader = new THREE.TextureLoader();
+
+    function showToast(message) {
+      toast.textContent = message;
+      toast.style.display = 'block';
+      window.clearTimeout(showToast.timer);
+      showToast.timer = window.setTimeout(() => {
+        toast.style.display = 'none';
+      }, 2600);
+    }
+
+    function applyTextureFromUrl(url) {
+      textureLoader.load(
+        url,
+        (texture) => {
+          texture.colorSpace = THREE.SRGBColorSpace;
+          const prevMap = material.map;
+          const prevMaterial = material;
+
+          material = new THREE.MeshBasicMaterial({ map: texture });
+          sphere.material = material;
+
+          if (prevMap) prevMap.dispose();
+          if (prevMaterial) prevMaterial.dispose();
+
+          placeholder.style.display = 'none';
+        },
+        undefined,
+        () => {
+          showToast('图片加载失败，请重试。');
+        }
+      );
+    }
+
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files?.[0];
+      if (!file) return;
+
+      const objectUrl = URL.createObjectURL(file);
+      const probe = new Image();
+      probe.onload = () => {
+        const ratio = probe.width / probe.height;
+        if (Math.abs(ratio - 2) > 0.03) {
+          showToast('当前图片不是标准 2:1，全景显示可能变形。');
+        }
+
+        applyTextureFromUrl(objectUrl);
+      };
+
+      probe.onerror = () => {
+        showToast('无法读取该图片文件。');
+      };
+
+      probe.src = objectUrl;
+    });
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    function animate() {
+      controls.update();
+      renderer.render(scene, camera);
+      requestAnimationFrame(animate);
+    }
+
+    animate();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- 提供一个独立的全屏黑底 360° 全景查看页面以便本地快速预览 equirectangular 全景图。
- 支持用户上传图片并在页面内直接查看以提升使用便捷性和可访问性。
- 在客户端做比例校验和失败提示以减少误用和提升可用性。
- 保持为独立页面实现，不改动现有站点路由或模板。

### Description
- 新增页面文件 `panorama-viewer.html`，实现覆盖视口的黑色后台和 UI 工具栏供文件上传与提示。
- 使用 `three`（通过 importmap）和 `OrbitControls` 在场景内创建反向球体（`SphereGeometry` + `geometry.scale(-1,1,1)`）并将贴图映射到球体内部以渲染全景。
- 实现文件上传处理流程：使用 `<input type="file">`、创建 `Image` probe 校验宽高比接近 2:1（误差阈值 0.03）并通过 `TextureLoader` 加载纹理；加载失败/读取失败触发 toast 提示。
- 对先前贴图/材质进行 `dispose()` 以释放资源，并实现响应式窗口 `resize` 处理与交互配置（禁用平移、启用阻尼、滚轮缩放范围等）。

### Testing
- 运行了 `git diff --check`，检查通过且未发现 whitespace/差异问题。 
- 未运行自动化 UI/渲染测试（页面渲染与交互需在浏览器中手动验证）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e8cb6e1883289579f9763a9c2097)