### PR TITLE
Add Panorama Viewer page and navigation entry

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,3 +6,5 @@
   url: "/about/"
 - title: "提示词生成器"
   url: "/prompt-generator/"
+- title: "全景 Viewer"
+  url: "/panorama-viewer/"

--- a/panorama-viewer.md
+++ b/panorama-viewer.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: "全景 Viewer"
+description: "上传 2:1 equirectangular 全景图，在浏览器中进行 360° 查看。"
+permalink: /panorama-viewer/
+---
+
+<p style="margin-bottom: 1rem; color: var(--text-secondary);">
+  使用说明：点击下方按钮进入全屏查看器，或直接在本页嵌入窗口中上传全景图（建议 2:1 比例）。
+</p>
+
+<p style="margin-bottom: 1rem;">
+  <a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener" class="btn btn-primary">
+    打开全屏全景 Viewer
+  </a>
+</p>
+
+<div style="border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; background: #0a0a0a;">
+  <iframe
+    src="{{ '/panorama-viewer.html' | relative_url }}"
+    title="全景 Viewer"
+    style="width: 100%; min-height: 760px; border: 0; display: block;"
+    loading="lazy">
+  </iframe>
+</div>


### PR DESCRIPTION
### Motivation
- Make the 360° 全景 viewer discoverable from the main site navigation so users don't need to know the direct URL.

### Description
- Add a navigation item in `_data/navigation.yml` titled `全景 Viewer` that links to `/panorama-viewer/`.
- Add a new page `panorama-viewer.md` with a `page` layout, a description, a button that opens `panorama-viewer.html` in a new tab, and an embedded iframe pointing to `panorama-viewer.html` for inline use.

### Testing
- Attempted `bundle exec jekyll build` which failed due to a missing `Gemfile` and Ruby dependencies in this environment.
- Verified the changes using `nl -ba _data/navigation.yml`, `nl -ba panorama-viewer.md`, and `git status --short`, which show the new navigation entry and page file as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ece7126c83288307745e8be61e04)