### PR TITLE
移动端优化：提示词生成器 UX 改进并移除导航冗余

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,5 @@
 - title: "首页"
   url: "/"
-- title: "工具列表"
-  url: "/#tools"
 - title: "提示词生成器"
   url: "/prompt-generator/"
 - title: "全景 Viewer"

--- a/prompt-generator-app.html
+++ b/prompt-generator-app.html
@@ -33,9 +33,10 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 40px 20px 60px;
+  padding: 28px 16px calc(28px + env(safe-area-inset-bottom));
   position: relative;
   overflow-x: hidden;
+  -webkit-tap-highlight-color: transparent;
 }
 
 body::before {
@@ -86,7 +87,7 @@ header {
 
 .cat-row {
   display: flex; align-items: center; gap: 12px;
-  padding: 10px 14px;
+  padding: 12px 14px;
   background: var(--surface);
   border: 1px solid var(--border);
   cursor: pointer;
@@ -105,7 +106,7 @@ header {
 .cat-row[data-cat="face"] .cat-dot { background: var(--tag-face); }
 .cat-row[data-cat="expression"] .cat-dot { background: var(--tag-expression); }
 
-.cat-label { font-size: 10px; letter-spacing: 0.2em; color: var(--muted); flex: 1; }
+.cat-label { font-size: 10px; letter-spacing: 0.16em; color: var(--muted); flex: 1; }
 .cat-row.active .cat-label { color: var(--text); }
 
 .cat-check {
@@ -121,6 +122,7 @@ header {
 .ar-row {
   display: flex; align-items: center; gap: 2px;
   margin-bottom: 20px; margin-top: 2px;
+  flex-wrap: wrap;
 }
 
 .ar-label {
@@ -144,9 +146,9 @@ header {
 .controls { display: flex; gap: 8px; margin-bottom: 24px; }
 
 .btn {
-  flex: 1; padding: 13px;
+  flex: 1; padding: 14px 10px;
   border: 1px solid var(--border); background: var(--surface); color: var(--text);
-  font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 0.25em;
+  font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 0.18em;
   cursor: pointer; transition: all 0.15s; text-transform: uppercase;
 }
 
@@ -217,6 +219,13 @@ header {
 
 .history-list { display: flex; flex-direction: column; gap: 2px; }
 
+.hint {
+  margin: -4px 0 14px;
+  font-size: 10px;
+  color: #8c8375;
+  letter-spacing: 0.06em;
+}
+
 .history-item {
   padding: 12px 14px;
   background: var(--surface); border: 1px solid var(--border);
@@ -249,6 +258,53 @@ header {
 }
 
 .output.flash { animation: pulse-border 0.6s ease-out; }
+
+@media (max-width: 768px) {
+  header {
+    margin-bottom: 20px;
+    gap: 8px;
+    padding-bottom: 14px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .categories {
+    grid-template-columns: 1fr;
+  }
+
+  .ar-label {
+    width: 100%;
+  }
+
+  .ar-btn {
+    flex: 1 1 calc(33.333% - 2px);
+    min-width: 80px;
+  }
+
+  .controls {
+    position: sticky;
+    bottom: 0;
+    background: linear-gradient(to top, rgba(10,10,10,0.98), rgba(10,10,10,0.86));
+    padding: 10px 0 calc(10px + env(safe-area-inset-bottom));
+    margin: 0 0 14px;
+    z-index: 10;
+  }
+
+  .btn {
+    min-height: 44px;
+  }
+
+  .output {
+    font-size: 14px;
+    line-height: 1.8;
+  }
+
+  .history-item {
+    font-size: 12px;
+    line-height: 1.8;
+    padding-right: 26px;
+  }
+}
 </style>
 </head>
 <body>
@@ -313,6 +369,7 @@ header {
     <button class="btn" id="copyBtn">⎘ 复制</button>
     <button class="btn" id="lockBtn">⊘ 锁定当前</button>
   </div>
+  <p class="hint">手机端操作建议：点击分类可开关，长按输出区可直接复制文本。</p>
 
   <div class="output-wrap">
     <span class="output-label">generated prompt</span>
@@ -538,12 +595,34 @@ document.getElementById('genBtn').addEventListener('click', generate);
 document.getElementById('copyBtn').addEventListener('click', () => {
   const text = document.getElementById('output').value;
   if (!text) return;
-  navigator.clipboard.writeText(text).then(() => {
+  const showCopied = () => {
     const fb = document.getElementById('copyFeedback');
     fb.classList.add('show');
     setTimeout(() => fb.classList.remove('show'), 1800);
-  });
+  };
+
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(showCopied).catch(() => fallbackCopy(text, showCopied));
+  } else {
+    fallbackCopy(text, showCopied);
+  }
 });
+
+function fallbackCopy(text, onSuccess) {
+  const temp = document.createElement('textarea');
+  temp.value = text;
+  temp.setAttribute('readonly', '');
+  temp.style.position = 'absolute';
+  temp.style.left = '-9999px';
+  document.body.appendChild(temp);
+  temp.select();
+  try {
+    document.execCommand('copy');
+    onSuccess();
+  } finally {
+    document.body.removeChild(temp);
+  }
+}
 
 document.getElementById('lockBtn').addEventListener('click', () => {
   locked = !locked;

--- a/prompt-generator.html
+++ b/prompt-generator.html
@@ -5,11 +5,15 @@ description: "随机组合风格标签，快速生成可复用的图像提示词
 permalink: /prompt-generator/
 ---
 
+<div style="margin-bottom: 0.75rem; color: var(--text-muted); font-size: 0.875rem;">
+  已针对手机端优先优化：单手可点按、按钮加大、操作区更聚焦。
+</div>
+
 <div style="border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; background: #0a0a0a;">
   <iframe
     src="{{ '/prompt-generator-app.html' | relative_url }}"
     title="提示词生成器"
-    style="width: 100%; min-height: 1300px; border: 0; display: block;"
+    style="width: 100%; min-height: min(100dvh, 980px); border: 0; display: block;"
     loading="lazy">
   </iframe>
 </div>


### PR DESCRIPTION
### Motivation
- 优化提示词生成器在手机端的可用性，提升单手操作体验并减少误触。 
- 移除顶栏中与首页内容重复的“工具列表”入口以精简导航。 
- 提升复制交互的可靠性，兼容部分移动浏览器的 clipboard 行为。 

### Description
- 从 `/_data/navigation.yml` 中移除了“工具列表”导航项以避免重复入口。 
- 在 `prompt-generator.html` 增加移动端提示文案并将 iframe 高度由固定值改为 `min(100dvh, 980px)` 以优化首屏表现。 
- 在 `prompt-generator-app.html` 中加入安全区适配和触控优化（修改页面内边距、禁用 tap highlight、放大触控目标、调整字距与 padding），并为 AR 按钮开启换行布局以便在窄屏下更好排列。 
- 将操作区在小屏幕上设为底部 `sticky`，增大按钮最小高度并加入移动端提示说明，且新增 `fallbackCopy` 函数作为 `navigator.clipboard.writeText` 的降级拷贝方案以提高兼容性。 

### Testing
- 已运行 `git diff --check`，结果通过。 
- 已运行 `git status --short`，变更文件列出为已修改。 
- 尝试运行 `bundle exec jekyll build` 进行本地构建时失败，原因是仓库中缺少 `Gemfile`/`.bundle`，因此无法在当前环境完成站点构建验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f2f7039083288829a2d884a6bbb1)