### PR TITLE
feat(home): add matching homepage artwork set

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -79,3 +79,25 @@
         }
     }
 }
+
+.home-gallery {
+    .image-card {
+        padding: 0.75rem;
+
+        img {
+            display: block;
+            width: 100%;
+            aspect-ratio: 16 / 9;
+            object-fit: cover;
+            border: 1px solid var(--border-color);
+            border-radius: 2px;
+            margin: 0 0 0.875rem 0;
+            box-shadow: none;
+        }
+
+        p {
+            font-size: 0.8125rem;
+            margin-bottom: 0;
+        }
+    }
+}

--- a/assets/images/homepage/scene-cyber-grid.svg
+++ b/assets/images/homepage/scene-cyber-grid.svg
@@ -1,0 +1,45 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="800" y1="0" x2="800" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0A0A0A"/>
+      <stop offset="1" stop-color="#111111"/>
+    </linearGradient>
+    <radialGradient id="sun" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 340) rotate(90) scale(220)">
+      <stop stop-color="#D4B88A" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#D4B88A" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#sun)"/>
+
+  <g opacity="0.42" stroke="#C8A97A" stroke-width="1.2">
+    <path d="M-100 820H1700"/>
+    <path d="M-160 770H1760"/>
+    <path d="M-230 710H1830"/>
+    <path d="M-310 640H1910"/>
+    <path d="M-410 560H2010"/>
+    <path d="M-540 460H2140"/>
+  </g>
+
+  <g opacity="0.38" stroke="#A89A80" stroke-width="1.2">
+    <path d="M800 900L140 460"/>
+    <path d="M800 900L260 460"/>
+    <path d="M800 900L380 460"/>
+    <path d="M800 900L500 460"/>
+    <path d="M800 900L620 460"/>
+    <path d="M800 900L740 460"/>
+    <path d="M800 900L860 460"/>
+    <path d="M800 900L980 460"/>
+    <path d="M800 900L1100 460"/>
+    <path d="M800 900L1220 460"/>
+    <path d="M800 900L1340 460"/>
+    <path d="M800 900L1460 460"/>
+  </g>
+
+  <g opacity="0.85">
+    <circle cx="800" cy="340" r="96" stroke="#E8E0D4" stroke-width="2"/>
+    <path d="M704 340H896" stroke="#E8E0D4" stroke-width="2"/>
+    <path d="M800 244V436" stroke="#E8E0D4" stroke-width="2"/>
+  </g>
+</svg>

--- a/assets/images/homepage/scene-mountain-scanline.svg
+++ b/assets/images/homepage/scene-mountain-scanline.svg
@@ -1,0 +1,40 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="800" y1="0" x2="800" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0A0A0A"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="fog" x1="800" y1="330" x2="800" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C8A97A" stop-opacity="0.24"/>
+      <stop offset="1" stop-color="#C8A97A" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#fog)"/>
+
+  <g opacity="0.55" stroke="#A89A80" stroke-width="1">
+    <path d="M0 520H1600"/>
+    <path d="M0 552H1600"/>
+    <path d="M0 584H1600"/>
+    <path d="M0 616H1600"/>
+    <path d="M0 648H1600"/>
+    <path d="M0 680H1600"/>
+    <path d="M0 712H1600"/>
+    <path d="M0 744H1600"/>
+    <path d="M0 776H1600"/>
+    <path d="M0 808H1600"/>
+  </g>
+
+  <g fill="#0F172A" stroke="#E8E0D4" stroke-width="2.2" opacity="0.88">
+    <path d="M210 640L470 300L690 640Z"/>
+    <path d="M540 640L850 240L1130 640Z"/>
+    <path d="M900 640L1210 330L1450 640Z"/>
+  </g>
+
+  <g opacity="0.85" stroke="#C8A97A" stroke-width="2">
+    <path d="M470 300L540 640"/>
+    <path d="M850 240L900 640"/>
+    <path d="M1130 640L1210 330"/>
+  </g>
+</svg>

--- a/assets/images/homepage/scene-terminal-city.svg
+++ b/assets/images/homepage/scene-terminal-city.svg
@@ -1,0 +1,44 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="800" y1="0" x2="800" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0A0A0A"/>
+      <stop offset="1" stop-color="#121212"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="800" y1="500" x2="800" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C8A97A" stop-opacity="0.2"/>
+      <stop offset="1" stop-color="#C8A97A" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#glow)"/>
+
+  <g opacity="0.7" stroke="#E8E0D4" stroke-width="2">
+    <path d="M120 770H1480"/>
+    <path d="M160 720H1440"/>
+    <path d="M210 670H1390"/>
+    <path d="M280 620H1320"/>
+  </g>
+
+  <g fill="#111111" stroke="#A89A80" stroke-width="2">
+    <rect x="220" y="360" width="180" height="260"/>
+    <rect x="410" y="300" width="200" height="320"/>
+    <rect x="640" y="250" width="160" height="370"/>
+    <rect x="820" y="280" width="220" height="340"/>
+    <rect x="1070" y="330" width="160" height="290"/>
+    <rect x="1240" y="390" width="130" height="230"/>
+  </g>
+
+  <g fill="#C8A97A" opacity="0.85">
+    <rect x="258" y="420" width="18" height="12"/>
+    <rect x="448" y="360" width="18" height="12"/>
+    <rect x="486" y="360" width="18" height="12"/>
+    <rect x="678" y="320" width="18" height="12"/>
+    <rect x="858" y="340" width="18" height="12"/>
+    <rect x="896" y="340" width="18" height="12"/>
+    <rect x="1110" y="390" width="18" height="12"/>
+    <rect x="1274" y="438" width="18" height="12"/>
+  </g>
+
+  <text x="800" y="152" text-anchor="middle" fill="#E8E0D4" font-size="46" font-family="monospace" letter-spacing="6">PIXEL.LOG</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,28 @@ title: "私人工具集 - 首页"
     </div>
 </section>
 
+<section class="home-gallery" style="margin-bottom: 3rem;">
+    <h2 style="margin-bottom: 1rem;">🖼️ 首页配图素材</h2>
+    <p class="text-muted" style="margin-bottom: 1.5rem;">统一暗色 + 复古像素氛围，可直接用于首页横幅、卡片封面或文章头图。</p>
+
+    <div class="grid grid--3-col">
+        <article class="card image-card">
+            <img src="{{ '/assets/images/homepage/scene-cyber-grid.svg' | relative_url }}" alt="赛博网格风格背景图">
+            <p class="text-muted">赛博网格 + 光晕中心，适合作为 Hero Banner。</p>
+        </article>
+
+        <article class="card image-card">
+            <img src="{{ '/assets/images/homepage/scene-terminal-city.svg' | relative_url }}" alt="终端城市风格背景图">
+            <p class="text-muted">极简线框城市夜景，适合工具卡片封面。</p>
+        </article>
+
+        <article class="card image-card">
+            <img src="{{ '/assets/images/homepage/scene-mountain-scanline.svg' | relative_url }}" alt="山脉扫描线风格背景图">
+            <p class="text-muted">扫描线山脉构图，适合文章列表视觉分隔。</p>
+        </article>
+    </div>
+</section>
+
 <section class="flag-section" style="margin-bottom: 3rem;">
     <h2 style="margin-bottom: 1rem;">🚩 飘荡的小红旗</h2>
     <p class="text-muted" style="margin-bottom: 1rem;">使用 Three.js 实现的轻量动态效果。</p>


### PR DESCRIPTION
### Motivation
- 提供一组与站点深色 + 暖金色调相匹配的可复用配图，便于用作首页横幅、卡片封面或文章头图。 
- 在页面层面直接暴露素材并添加样式，以确保这些图像能与现有卡片/网格布局一致显示。

### Description
- 新增三张矢量 SVG 资产：`assets/images/homepage/scene-cyber-grid.svg`、`scene-terminal-city.svg`、`scene-mountain-scanline.svg`。 
- 在 `index.html` 中添加一个新的“🖼️ 首页配图素材”展示区（`.home-gallery`），使用 `.grid grid--3-col` 布局并为每张图提供 `alt` 文本与说明。 
- 在 `_sass/components/_terminal.scss` 中新增 `.home-gallery .image-card` 样式以统一图片 `aspect-ratio: 16/9`、边框、圆角与说明文字样式，保证响应式表现与现有卡片系统一致。 
- 已将更改提交（提交信息：`feat(home): add matching homepage artwork set`）。

### Testing
- 运行 `git status --short` 成功。 
- 通过 `git commit` 提交成功。 
- 尝试运行 `bundle exec jekyll build` 失败（当前环境缺少 `Gemfile` / bundler 配置），因此无法在此容器内完成站点构建验证。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca58e398c832889430e134abf41c3)