### PR TITLE
Add frameless page mode and redesign homepage/tool pages with new styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,10 +14,14 @@
     <div class="container">
         {% include header.html %}
 
-        <main class="main-content">
+        <main class="main-content{% if page.no_frame %} main-content--full{% endif %}">
+            {% if page.no_frame %}
+                {{ content }}
+            {% else %}
             <div class="card">
                 {{ content }}
             </div>
+            {% endif %}
         </main>
 
         {% include footer.html %}

--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -8,34 +8,31 @@
     padding: 1.5rem;
     box-shadow: none;
     transition: border-color 0.2s ease;
-    
+
     &:hover {
         border-color: #2f2f2f;
     }
-    
-    // Card content styling
+
     h1, h2, h3, h4, h5, h6 {
         color: var(--primary-color);
         margin-bottom: 0.75rem;
     }
-    
+
     p {
         color: var(--text-color);
         margin-bottom: 1rem;
-        
+
         &:last-child {
             margin-bottom: 0;
         }
     }
-    
-    // Responsive card
+
     @media (max-width: $mobile) {
         padding: 1rem;
         border-radius: 6px;
     }
 }
 
-// Container layouts
 .container {
     min-height: 100vh;
     display: flex;
@@ -50,54 +47,181 @@
     width: 100%;
 }
 
-// Grid layouts
+.main-content--full {
+    max-width: 1100px;
+}
+
 .grid {
     display: grid;
     gap: 1.5rem;
-    
+
     &--auto-fit {
         grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     }
-    
+
     &--2-col {
         grid-template-columns: repeat(2, 1fr);
-        
+
         @media (max-width: $tablet) {
             grid-template-columns: 1fr;
         }
     }
-    
+
     &--3-col {
         grid-template-columns: repeat(3, 1fr);
-        
+
         @media (max-width: $tablet) {
             grid-template-columns: repeat(2, 1fr);
         }
-        
+
         @media (max-width: $mobile) {
             grid-template-columns: 1fr;
         }
     }
 }
 
-.home-gallery {
-    .image-card {
-        padding: 0.75rem;
+.home-shell {
+    display: grid;
+    gap: 1.25rem;
+}
 
-        img {
-            display: block;
-            width: 100%;
-            aspect-ratio: 16 / 9;
-            object-fit: cover;
-            border: 1px solid var(--border-color);
-            border-radius: 2px;
-            margin: 0 0 0.875rem 0;
-            box-shadow: none;
-        }
+.section-panel {
+    background: linear-gradient(180deg, rgba(17, 17, 17, 0.94), rgba(17, 17, 17, 0.72));
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1.4rem;
+}
 
-        p {
-            font-size: 0.8125rem;
-            margin-bottom: 0;
-        }
+.section-head {
+    margin-bottom: 1rem;
+
+    h2 {
+        margin-bottom: 0.55rem;
     }
+
+    p {
+        margin-bottom: 0;
+        font-size: 0.875rem;
+    }
+}
+
+.section-kicker {
+    color: var(--accent-color);
+    letter-spacing: 0.22em;
+    font-size: 0.68rem;
+    margin-bottom: 0.8rem;
+}
+
+.hero-subtitle {
+    margin: 0 auto;
+    max-width: 42rem;
+    color: var(--secondary-color);
+}
+
+.tool-card,
+.media-card {
+    background: rgba(10, 10, 10, 0.64);
+    border: 1px solid rgba(200, 169, 122, 0.2);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.tool-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    h3,
+    p {
+        margin-bottom: 0;
+    }
+
+    .meta {
+        color: var(--secondary-color);
+        font-size: 0.78rem;
+    }
+
+    .btn {
+        margin-top: 0.35rem;
+        width: fit-content;
+    }
+}
+
+.media-card {
+    img {
+        display: block;
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        object-fit: cover;
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        margin: 0 0 0.75rem;
+    }
+
+    p {
+        margin: 0;
+        font-size: 0.8125rem;
+    }
+}
+
+#floating-flag {
+    height: 260px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    background: linear-gradient(180deg, #0f172a, #111827);
+}
+
+
+.tool-page {
+    display: grid;
+    gap: 0.9rem;
+    padding: 1.2rem;
+    background: linear-gradient(180deg, rgba(17, 17, 17, 0.94), rgba(17, 17, 17, 0.72));
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+}
+
+.tool-page__intro {
+    padding: 0.85rem 1rem;
+    background: rgba(10, 10, 10, 0.62);
+    border: 1px solid rgba(200, 169, 122, 0.18);
+    border-radius: 8px;
+}
+
+.tool-page__intro--split {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    @media (max-width: $tablet) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+.tool-page__note {
+    margin: 0;
+    color: var(--secondary-color);
+    font-size: 0.875rem;
+    line-height: 1.6;
+}
+
+.tool-embed {
+    overflow: hidden;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    background: #0a0a0a;
+
+    iframe {
+        width: 100%;
+        min-height: min(100dvh, 980px);
+        border: 0;
+        display: block;
+    }
+}
+
+.tool-embed--tall iframe {
+    min-height: 760px;
 }

--- a/index.html
+++ b/index.html
@@ -1,60 +1,71 @@
 ---
 layout: default
 title: "私人工具集 - 首页"
+no_frame: true
 ---
 
-<section class="hero-section text-center" style="margin-bottom: 3rem;">
-    <h1>私人使用工具集</h1>
-    <p class="text-muted" style="font-size: 1.125rem; margin: 1rem 0;">仅用于个人效率与创作场景，不对外提供在线服务。</p>
-</section>
+<div class="home-shell">
+    <section class="hero-section text-center section-panel">
+        <p class="section-kicker">PRIVATE TOOLKIT</p>
+        <h1>私人使用工具集</h1>
+        <p class="hero-subtitle">仅用于个人效率与创作场景，不对外提供在线服务。</p>
+    </section>
 
-<section id="tools" class="features-section" style="margin-bottom: 3rem;">
-    <h2 style="margin-bottom: 2rem;">🧰 工具列表</h2>
+    <section id="tools" class="features-section section-panel">
+        <div class="section-head">
+            <h2>🧰 工具列表</h2>
+            <p class="text-muted">两个常用入口，直接打开使用。</p>
+        </div>
 
-    <div class="grid grid--auto-fit">
-        <article class="card">
-            <h3>✨ 提示词生成器</h3>
-            <p>快速组织输入信息，生成结构化提示词，用于日常创作与 AI 协作。</p>
-            <p class="text-muted" style="font-size: 0.875rem;">最近更新：2026-04-22</p>
-            <a href="{{ '/prompt-generator/' | relative_url }}" class="btn">打开工具</a>
-        </article>
+        <div class="grid grid--auto-fit">
+            <article class="tool-card">
+                <h3>✨ 提示词生成器</h3>
+                <p>快速组织输入信息，生成结构化提示词，用于日常创作与 AI 协作。</p>
+                <p class="meta">最近更新：2026-04-22</p>
+                <a href="{{ '/prompt-generator/' | relative_url }}" class="btn">打开工具</a>
+            </article>
 
-        <article class="card">
-            <h3>🌄 全景 Viewer</h3>
-            <p>用于本地查看和浏览全景素材，方便筛选、对比和快速预览。</p>
-            <p class="text-muted" style="font-size: 0.875rem;">最近更新：2026-04-22</p>
-            <a href="{{ '/panorama-viewer/' | relative_url }}" class="btn">打开工具</a>
-        </article>
-    </div>
-</section>
+            <article class="tool-card">
+                <h3>🌄 全景 Viewer</h3>
+                <p>用于本地查看和浏览全景素材，方便筛选、对比和快速预览。</p>
+                <p class="meta">最近更新：2026-04-22</p>
+                <a href="{{ '/panorama-viewer/' | relative_url }}" class="btn">打开工具</a>
+            </article>
+        </div>
+    </section>
 
-<section class="home-gallery" style="margin-bottom: 3rem;">
-    <h2 style="margin-bottom: 1rem;">🖼️ 首页配图素材</h2>
-    <p class="text-muted" style="margin-bottom: 1.5rem;">统一暗色 + 复古像素氛围，可直接用于首页横幅、卡片封面或文章头图。</p>
+    <section class="home-gallery section-panel">
+        <div class="section-head">
+            <h2>🖼️ 首页配图素材</h2>
+            <p class="text-muted">统一暗色 + 复古像素氛围，可直接用于首页横幅、卡片封面或文章头图。</p>
+        </div>
 
-    <div class="grid grid--3-col">
-        <article class="card image-card">
-            <img src="{{ '/assets/images/homepage/scene-cyber-grid.svg' | relative_url }}" alt="赛博网格风格背景图">
-            <p class="text-muted">赛博网格 + 光晕中心，适合作为 Hero Banner。</p>
-        </article>
+        <div class="grid grid--3-col">
+            <article class="media-card">
+                <img src="{{ '/assets/images/homepage/scene-cyber-grid.svg' | relative_url }}" alt="赛博网格风格背景图">
+                <p>赛博网格 + 光晕中心，适合作为 Hero Banner。</p>
+            </article>
 
-        <article class="card image-card">
-            <img src="{{ '/assets/images/homepage/scene-terminal-city.svg' | relative_url }}" alt="终端城市风格背景图">
-            <p class="text-muted">极简线框城市夜景，适合工具卡片封面。</p>
-        </article>
+            <article class="media-card">
+                <img src="{{ '/assets/images/homepage/scene-terminal-city.svg' | relative_url }}" alt="终端城市风格背景图">
+                <p>极简线框城市夜景，适合工具卡片封面。</p>
+            </article>
 
-        <article class="card image-card">
-            <img src="{{ '/assets/images/homepage/scene-mountain-scanline.svg' | relative_url }}" alt="山脉扫描线风格背景图">
-            <p class="text-muted">扫描线山脉构图，适合文章列表视觉分隔。</p>
-        </article>
-    </div>
-</section>
+            <article class="media-card">
+                <img src="{{ '/assets/images/homepage/scene-mountain-scanline.svg' | relative_url }}" alt="山脉扫描线风格背景图">
+                <p>扫描线山脉构图，适合文章列表视觉分隔。</p>
+            </article>
+        </div>
+    </section>
 
-<section class="flag-section" style="margin-bottom: 3rem;">
-    <h2 style="margin-bottom: 1rem;">🚩 飘荡的小红旗</h2>
-    <p class="text-muted" style="margin-bottom: 1rem;">使用 Three.js 实现的轻量动态效果。</p>
-    <div id="floating-flag" style="height: 260px; border-radius: 12px; overflow: hidden; background: linear-gradient(180deg, #0f172a, #111827);"></div>
-</section>
+    <section class="flag-section section-panel">
+        <div class="section-head">
+            <h2>🚩 飘荡的小红旗</h2>
+            <p class="text-muted">使用 Three.js 实现的轻量动态效果。</p>
+        </div>
+        <div id="floating-flag"></div>
+    </section>
+</div>
 
 <script type="module">
     import * as THREE from 'https://unpkg.com/three@0.165.0/build/three.module.js';

--- a/panorama-viewer.md
+++ b/panorama-viewer.md
@@ -3,23 +3,25 @@ layout: page
 title: "全景 Viewer"
 description: "上传 2:1 equirectangular 全景图，在浏览器中进行 360° 查看。"
 permalink: /panorama-viewer/
+no_frame: true
 ---
 
-<p style="margin-bottom: 1rem; color: var(--text-secondary);">
-  使用说明：点击下方按钮进入全屏查看器，或直接在本页嵌入窗口中上传全景图（建议 2:1 比例）。
-</p>
+<section class="tool-page">
+  <div class="tool-page__intro tool-page__intro--split">
+    <p class="tool-page__note">
+      使用说明：点击下方按钮进入全屏查看器，或直接在本页嵌入窗口中上传全景图（建议 2:1 比例）。
+    </p>
 
-<p style="margin-bottom: 1rem;">
-  <a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener" class="btn btn-primary">
-    打开全屏全景 Viewer
-  </a>
-</p>
+    <a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener" class="btn">
+      打开全屏全景 Viewer
+    </a>
+  </div>
 
-<div style="border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; background: #0a0a0a;">
-  <iframe
-    src="{{ '/panorama-viewer.html' | relative_url }}"
-    title="全景 Viewer"
-    style="width: 100%; min-height: 760px; border: 0; display: block;"
-    loading="lazy">
-  </iframe>
-</div>
+  <div class="tool-embed tool-embed--tall">
+    <iframe
+      src="{{ '/panorama-viewer.html' | relative_url }}"
+      title="全景 Viewer"
+      loading="lazy">
+    </iframe>
+  </div>
+</section>

--- a/prompt-generator.html
+++ b/prompt-generator.html
@@ -3,17 +3,21 @@ layout: page
 title: "提示词生成器"
 description: "随机组合风格标签，快速生成可复用的图像提示词。"
 permalink: /prompt-generator/
+no_frame: true
 ---
 
-<div style="margin-bottom: 0.75rem; color: var(--text-muted); font-size: 0.875rem;">
-  已针对手机端优先优化：单手可点按、按钮加大、操作区更聚焦。
-</div>
+<section class="tool-page">
+  <div class="tool-page__intro">
+    <p class="tool-page__note">
+      已针对手机端优先优化：单手可点按、按钮加大、操作区更聚焦。
+    </p>
+  </div>
 
-<div style="border: 1px solid var(--border-color); border-radius: 8px; overflow: hidden; background: #0a0a0a;">
-  <iframe
-    src="{{ '/prompt-generator-app.html' | relative_url }}"
-    title="提示词生成器"
-    style="width: 100%; min-height: min(100dvh, 980px); border: 0; display: block;"
-    loading="lazy">
-  </iframe>
-</div>
+  <div class="tool-embed">
+    <iframe
+      src="{{ '/prompt-generator-app.html' | relative_url }}"
+      title="提示词生成器"
+      loading="lazy">
+    </iframe>
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide a frameless page mode to embed full-bleed tools and iframes without the default card chrome. 
- Modernize the homepage and tool pages with a darker, modular UI and reusable components for tool/media sections. 

### Description
- Add `no_frame` front-matter flag and conditional layout logic in `_layouts/default.html` to render pages without the `.card` wrapper when `page.no_frame` is true. 
- Expand and reorganize Sass in `_sass/components/_terminal.scss` with new utility and component classes (`.main-content--full`, `.section-panel`, `.tool-card`, `.media-card`, `.tool-page`, `.tool-embed`, etc.) and responsive rules. 
- Replace the old `index.html` content with a structured, componentized homepage (`.home-shell`, section headers, tool/media cards) and set `no_frame: true` for full-bleed presentation. 
- Update `panorama-viewer.md` and `prompt-generator.html` to use the new `.tool-page` layout, embed tools via `.tool-embed` iframes, and enable `no_frame: true` so embedded tools render without additional framing. 

### Testing
- Ran a local site build with `bundle exec jekyll build` to verify templates and front-matter changes and the build completed successfully. 
- Verified basic iframe embedding and layout classes by previewing the affected pages in a dev server and confirming key sections render as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca6dfdab08328b5d3733d65ff36f8)