### PR TITLE
feat: mobile-first redesign for navigation and tool workflows

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,11 +3,11 @@ layout: default
 ---
 
 <article class="page">
-    <header class="page-header" style="margin-bottom: 2rem;">
+    <header class="page-header">
         <h1>{{ page.title }}</h1>
         
         {% if page.description %}
-            <p class="text-muted" style="font-size: 1.125rem; margin-top: 0.5rem;">{{ page.description }}</p>
+            <p class="page-description text-muted">{{ page.description }}</p>
         {% endif %}
     </header>
     
@@ -16,8 +16,8 @@ layout: default
     </div>
     
     {% if page.show_modified_date and page.last_modified_at %}
-        <footer class="page-footer" style="margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">
-            <p class="text-muted" style="font-size: 0.875rem;">
+        <footer class="page-footer">
+            <p class="text-muted page-modified-date">
                 🕒 最后更新: {{ page.last_modified_at | date: "%Y年%m月%d日" }}
             </p>
         </footer>

--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -77,14 +77,16 @@
 // Navigation buttons
 .nav-link {
     display: inline-block;
-    padding: 0.5rem 0.75rem;
+    padding: 0.55rem 0.8rem;
     color: var(--text-color);
     text-decoration: none;
-    font-weight: 400;
+    font-weight: 600;
     font-size: 0.72rem;
-    letter-spacing: 0.18em;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    border: 1px solid transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: rgba(17, 17, 17, 0.6);
     transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
     
     &:hover {
@@ -96,5 +98,18 @@
     &.active {
         color: var(--accent-color);
         font-weight: 600;
+    }
+}
+
+@media (max-width: $mobile) {
+    .nav-link {
+        display: flex;
+        min-height: 44px;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem;
+        font-size: 0.66rem;
+        letter-spacing: 0.08em;
+        width: 100%;
     }
 }

--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -41,7 +41,7 @@
 
 .main-content {
     flex: 1;
-    padding: 2rem 1rem;
+    padding: 1.2rem 0.85rem 2rem;
     max-width: 900px;
     margin: 0 auto;
     width: 100%;
@@ -49,6 +49,12 @@
 
 .main-content--full {
     max-width: 1100px;
+}
+
+@media (min-width: $tablet) {
+    .main-content {
+        padding: 1.75rem 1rem 2.4rem;
+    }
 }
 
 .grid {
@@ -89,7 +95,13 @@
     background: linear-gradient(180deg, rgba(17, 17, 17, 0.94), rgba(17, 17, 17, 0.72));
     border: 1px solid var(--border-color);
     border-radius: 10px;
-    padding: 1.4rem;
+    padding: 1rem;
+}
+
+@media (min-width: $tablet) {
+    .section-panel {
+        padding: 1.4rem;
+    }
 }
 
 .section-head {
@@ -143,6 +155,13 @@
 
     .btn {
         margin-top: 0.35rem;
+        width: 100%;
+        min-height: 44px;
+    }
+}
+
+@media (min-width: $tablet) {
+    .tool-card .btn {
         width: fit-content;
     }
 }
@@ -175,15 +194,15 @@
 
 .tool-page {
     display: grid;
-    gap: 0.9rem;
-    padding: 1.2rem;
+    gap: 0.75rem;
+    padding: 0.85rem;
     background: linear-gradient(180deg, rgba(17, 17, 17, 0.94), rgba(17, 17, 17, 0.72));
     border: 1px solid var(--border-color);
     border-radius: 10px;
 }
 
 .tool-page__intro {
-    padding: 0.85rem 1rem;
+    padding: 0.85rem;
     background: rgba(10, 10, 10, 0.62);
     border: 1px solid rgba(200, 169, 122, 0.18);
     border-radius: 8px;
@@ -204,8 +223,8 @@
 .tool-page__note {
     margin: 0;
     color: var(--secondary-color);
-    font-size: 0.875rem;
-    line-height: 1.6;
+    font-size: 1rem;
+    line-height: 1.65;
 }
 
 .tool-embed {
@@ -216,12 +235,72 @@
 
     iframe {
         width: 100%;
-        min-height: min(100dvh, 980px);
+        min-height: min(78dvh, 920px);
         border: 0;
         display: block;
     }
 }
 
 .tool-embed--tall iframe {
-    min-height: 760px;
+    min-height: min(82dvh, 840px);
+}
+
+@media (min-width: $tablet) {
+    .tool-page {
+        gap: 0.9rem;
+        padding: 1.2rem;
+    }
+
+    .tool-page__intro {
+        padding: 0.85rem 1rem;
+    }
+
+    .tool-page__note {
+        font-size: 0.875rem;
+        line-height: 1.6;
+    }
+
+    .tool-embed iframe {
+        min-height: min(100dvh, 980px);
+    }
+
+    .tool-embed--tall iframe {
+        min-height: 760px;
+    }
+}
+
+.page-header {
+    margin-bottom: 1.25rem;
+}
+
+.page-description {
+    font-size: 1rem;
+    margin-top: 0.45rem;
+    line-height: 1.6;
+}
+
+.page-footer {
+    margin-top: 1.75rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.page-modified-date {
+    font-size: 0.875rem;
+}
+
+@media (min-width: $tablet) {
+    .page-header {
+        margin-bottom: 2rem;
+    }
+
+    .page-description {
+        font-size: 1.125rem;
+        margin-top: 0.5rem;
+    }
+
+    .page-footer {
+        margin-top: 2rem;
+        padding-top: 1rem;
+    }
 }

--- a/_sass/layout/_header.scss
+++ b/_sass/layout/_header.scss
@@ -4,7 +4,7 @@
 .site-header {
     background: var(--surface-color);
     border-bottom: 1px solid var(--border-color);
-    padding: 1.25rem 0;
+    padding: 0.9rem 0;
     position: sticky;
     top: 0;
     z-index: 100;
@@ -15,17 +15,16 @@
 .site-nav {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 0 1rem;
+    padding: 0 0.9rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0.8rem;
 }
 
 .nav-menu {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.45rem;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -48,12 +47,28 @@
 
 // Responsive navigation
 @media (max-width: $mobile) {
+    .site-header {
+        padding: 0.75rem 0;
+    }
+
     .site-nav {
         flex-direction: column;
-        text-align: center;
+        align-items: stretch;
+        gap: 0.75rem;
     }
     
     .site-title {
-        font-size: 1.25rem;
+        text-align: center;
+    }
+
+    .nav-menu {
+        width: 100%;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.45rem;
+    }
+
+    .nav-menu li {
+        width: 100%;
     }
 }

--- a/panorama-viewer.html
+++ b/panorama-viewer.html
@@ -27,31 +27,35 @@
 
     .toolbar {
       position: fixed;
-      top: 16px;
+      bottom: max(10px, env(safe-area-inset-bottom));
       left: 50%;
       transform: translateX(-50%);
       z-index: 20;
-      display: inline-flex;
-      align-items: center;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
       gap: 10px;
-      padding: 10px 14px;
-      border-radius: 12px;
-      background: rgba(0, 0, 0, 0.55);
-      border: 1px solid rgba(255, 255, 255, 0.2);
+      width: min(92vw, 560px);
+      padding: 10px;
+      border-radius: 14px;
+      background: rgba(0, 0, 0, 0.62);
+      border: 1px solid rgba(255, 255, 255, 0.16);
       backdrop-filter: blur(6px);
       -webkit-backdrop-filter: blur(6px);
     }
 
     .upload-btn {
-      display: inline-flex;
+      display: flex;
       align-items: center;
       justify-content: center;
-      padding: 8px 12px;
+      width: 100%;
+      min-height: 46px;
+      padding: 10px 12px;
       border-radius: 8px;
       background: #2e7bff;
       color: #fff;
       cursor: pointer;
-      font-size: 14px;
+      font-size: 15px;
       font-weight: 600;
       border: none;
       transition: transform 0.15s ease, background 0.2s ease;
@@ -63,10 +67,10 @@
     #fileInput { display: none; }
 
     .tips {
-      font-size: 13px;
+      font-size: 12px;
       line-height: 1.4;
       color: rgba(255, 255, 255, 0.85);
-      white-space: nowrap;
+      text-align: center;
     }
 
     .toast {
@@ -96,6 +100,31 @@
       padding: 24px;
       pointer-events: none;
     }
+
+    @media (min-width: 768px) {
+      .toolbar {
+        top: 16px;
+        bottom: auto;
+        flex-direction: row;
+        align-items: center;
+        width: auto;
+        max-width: min(92vw, 960px);
+        padding: 10px 14px;
+      }
+
+      .upload-btn {
+        width: auto;
+        min-height: auto;
+        padding: 8px 12px;
+        font-size: 14px;
+      }
+
+      .tips {
+        font-size: 13px;
+        white-space: nowrap;
+        text-align: left;
+      }
+    }
   </style>
 </head>
 <body>
@@ -104,7 +133,7 @@
   <div class="toolbar">
     <label class="upload-btn" for="fileInput">上传全景图</label>
     <input id="fileInput" type="file" accept="image/*" />
-    <span class="tips">拖拽/单指旋转 · 滚轮/双指缩放（建议 2:1 equirectangular）</span>
+    <span class="tips">单指拖动旋转 · 双指缩放（建议 2:1 equirectangular）</span>
   </div>
 
   <div id="placeholder" class="placeholder">

--- a/panorama-viewer.md
+++ b/panorama-viewer.md
@@ -9,7 +9,7 @@ no_frame: true
 <section class="tool-page">
   <div class="tool-page__intro tool-page__intro--split">
     <p class="tool-page__note">
-      使用说明：点击下方按钮进入全屏查看器，或直接在本页嵌入窗口中上传全景图（建议 2:1 比例）。
+      使用说明：优先为手机端手势操作优化。可先点按钮进入全屏查看器，也可直接在下方嵌入窗口上传全景图（建议 2:1 比例）。
     </p>
 
     <a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener" class="btn">

--- a/prompt-generator-app.html
+++ b/prompt-generator-app.html
@@ -33,7 +33,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 28px 16px calc(28px + env(safe-area-inset-bottom));
+  padding: 18px 12px calc(22px + env(safe-area-inset-bottom));
   position: relative;
   overflow-x: hidden;
   -webkit-tap-highlight-color: transparent;
@@ -52,7 +52,7 @@ body::before {
 header {
   width: 100%;
   max-width: 780px;
-  margin-bottom: 32px;
+  margin-bottom: 18px;
   border-bottom: 1px solid var(--border);
   padding-bottom: 20px;
   display: flex;
@@ -65,7 +65,7 @@ header {
 .main { width: 100%; max-width: 780px; }
 
 .subject-bar {
-  padding: 10px 14px;
+  padding: 12px;
   background: rgba(200,169,122,0.05);
   border: 1px solid rgba(200,169,122,0.2);
   margin-bottom: 2px;
@@ -74,8 +74,8 @@ header {
   gap: 10px;
 }
 
-.subject-label { font-size: 9px; letter-spacing: 0.25em; color: var(--accent); text-transform: uppercase; white-space: nowrap; }
-.subject-text { font-size: 10px; color: #a89a80; font-family: 'Noto Serif SC', serif; letter-spacing: 0.03em; flex: 1; }
+.subject-label { font-size: 10px; letter-spacing: 0.2em; color: var(--accent); text-transform: uppercase; white-space: nowrap; }
+.subject-text { font-size: 12px; color: #a89a80; font-family: 'Noto Serif SC', serif; letter-spacing: 0.03em; flex: 1; }
 .subject-lock { font-size: 9px; color: var(--accent); opacity: 0.5; letter-spacing: 0.1em; }
 
 .categories {
@@ -87,7 +87,7 @@ header {
 
 .cat-row {
   display: flex; align-items: center; gap: 12px;
-  padding: 12px 14px;
+  padding: 14px 12px;
   background: var(--surface);
   border: 1px solid var(--border);
   cursor: pointer;
@@ -106,11 +106,11 @@ header {
 .cat-row[data-cat="face"] .cat-dot { background: var(--tag-face); }
 .cat-row[data-cat="expression"] .cat-dot { background: var(--tag-expression); }
 
-.cat-label { font-size: 10px; letter-spacing: 0.16em; color: var(--muted); flex: 1; }
+.cat-label { font-size: 12px; letter-spacing: 0.1em; color: var(--muted); flex: 1; }
 .cat-row.active .cat-label { color: var(--text); }
 
 .cat-check {
-  width: 14px; height: 14px;
+  width: 18px; height: 18px;
   border: 1px solid var(--border);
   display: flex; align-items: center; justify-content: center;
   font-size: 9px; color: var(--accent);
@@ -121,34 +121,34 @@ header {
 
 .ar-row {
   display: flex; align-items: center; gap: 2px;
-  margin-bottom: 20px; margin-top: 2px;
+  margin-bottom: 14px; margin-top: 2px;
   flex-wrap: wrap;
 }
 
 .ar-label {
-  font-size: 9px; letter-spacing: 0.2em; color: var(--muted);
-  padding: 8px 14px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--muted);
+  padding: 10px 12px;
   background: var(--surface); border: 1px solid var(--border);
   white-space: nowrap;
 }
 
 .ar-btn {
-  padding: 8px 0;
+  padding: 11px 0;
   background: var(--surface); border: 1px solid var(--border);
   color: var(--muted);
-  font-family: 'Space Mono', monospace; font-size: 9px; letter-spacing: 0.1em;
+  font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.08em;
   cursor: pointer; transition: all 0.15s; flex: 1; text-align: center;
 }
 
 .ar-btn:hover { border-color: #333; color: var(--text); }
 .ar-btn.active { border-color: var(--accent); color: var(--accent); background: rgba(200,169,122,0.05); }
 
-.controls { display: flex; gap: 8px; margin-bottom: 24px; }
+.controls { display: flex; gap: 8px; margin-bottom: 18px; }
 
 .btn {
   flex: 1; padding: 14px 10px;
   border: 1px solid var(--border); background: var(--surface); color: var(--text);
-  font-family: 'Space Mono', monospace; font-size: 10px; letter-spacing: 0.18em;
+  font-family: 'Space Mono', monospace; font-size: 11px; letter-spacing: 0.12em;
   cursor: pointer; transition: all 0.15s; text-transform: uppercase;
 }
 
@@ -160,10 +160,10 @@ header {
 .output-wrap { position: relative; margin-bottom: 16px; }
 
 .output {
-  width: 100%; min-height: 180px; padding: 20px 20px 40px;
+  width: 100%; min-height: 220px; padding: 16px 14px 38px;
   background: var(--surface); border: 1px solid var(--border);
   color: var(--text);
-  font-family: 'Noto Serif SC', serif; font-size: 13px; line-height: 1.9;
+  font-family: 'Noto Serif SC', serif; font-size: 14px; line-height: 1.8;
   resize: none; outline: none; transition: border-color 0.2s; letter-spacing: 0.02em;
 }
 
@@ -227,9 +227,9 @@ header {
 }
 
 .history-item {
-  padding: 12px 14px;
+  padding: 13px 12px;
   background: var(--surface); border: 1px solid var(--border);
-  font-family: 'Noto Serif SC', serif; font-size: 11px; line-height: 1.7;
+  font-family: 'Noto Serif SC', serif; font-size: 12px; line-height: 1.75;
   color: #888; cursor: pointer; transition: all 0.15s; position: relative;
 }
 
@@ -285,8 +285,8 @@ header {
     position: sticky;
     bottom: 0;
     background: linear-gradient(to top, rgba(10,10,10,0.98), rgba(10,10,10,0.86));
-    padding: 10px 0 calc(10px + env(safe-area-inset-bottom));
-    margin: 0 0 14px;
+    padding: 10px 0 calc(12px + env(safe-area-inset-bottom));
+    margin: 0 0 10px;
     z-index: 10;
   }
 
@@ -295,12 +295,12 @@ header {
   }
 
   .output {
-    font-size: 14px;
+    font-size: 15px;
     line-height: 1.8;
   }
 
   .history-item {
-    font-size: 12px;
+    font-size: 13px;
     line-height: 1.8;
     padding-right: 26px;
   }

--- a/prompt-generator.html
+++ b/prompt-generator.html
@@ -9,7 +9,7 @@ no_frame: true
 <section class="tool-page">
   <div class="tool-page__intro">
     <p class="tool-page__note">
-      已针对手机端优先优化：单手可点按、按钮加大、操作区更聚焦。
+      已按手机端优先重排：单手区可点按、按钮更大、内容区更聚焦。
     </p>
   </div>
 


### PR DESCRIPTION
### Motivation
- Improve one-handed / phone-first usability across the private toolkit pages by reorganizing spacing, controls and interaction patterns so common actions are easier to tap and see on mobile screens.

### Description
- Reworked top navigation and mobile behavior to a tappable 3-column grid with larger touch targets and visual affordances (changes in `_sass/layout/_header.scss` and `_sass/components/_buttons.scss`).
- Converted page header inline styles into class-based layout and added responsive page header/modified-date styles (`_layouts/page.html`, `_sass/components/_terminal.scss`).
- Tuned tool panels, card buttons and embed iframes for mobile ergonomics (full‑width/min‑height CTAs on small screens and viewport-aware iframe heights) in `_sass/components/_terminal.scss` and `prompt-generator-app.html`.
- Redesigned the panorama viewer toolbar into a mobile bottom-sheet pattern with a larger upload CTA and shorter gesture hint while preserving desktop layout in `panorama-viewer.html` and updated the viewer description in `panorama-viewer.md` and `prompt-generator.html`.

### Testing
- Inspected diffs for the updated files to validate changes: `_layouts/page.html`, `_sass/layout/_header.scss`, `_sass/components/_buttons.scss`, `_sass/components/_terminal.scss`, `prompt-generator.html`, `prompt-generator-app.html`, `panorama-viewer.html`, and `panorama-viewer.md` (diff review succeeded). 
- Attempted `bundle exec jekyll build` in this environment and it failed due to a missing `Gemfile`/`.bundle`, so a full site build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecae11be748328ae953b29953d31af)