### PR TITLE
精简首页与工具页，统一单层边框视觉

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -93,7 +93,6 @@
 
 .section-panel {
     background: linear-gradient(180deg, rgba(17, 17, 17, 0.94), rgba(17, 17, 17, 0.72));
-    border: 1px solid var(--border-color);
     border-radius: 10px;
     padding: 1rem;
 }
@@ -133,7 +132,6 @@
 .tool-card,
 .media-card {
     background: rgba(10, 10, 10, 0.64);
-    border: 1px solid rgba(200, 169, 122, 0.2);
     border-radius: 8px;
     padding: 1rem;
 }
@@ -202,10 +200,9 @@
 }
 
 .tool-page__intro {
-    padding: 0.85rem;
-    background: rgba(10, 10, 10, 0.62);
-    border: 1px solid rgba(200, 169, 122, 0.18);
-    border-radius: 8px;
+    padding: 0;
+    background: transparent;
+    border-radius: 0;
 }
 
 .tool-page__intro--split {
@@ -225,12 +222,16 @@
     color: var(--secondary-color);
     font-size: 1rem;
     line-height: 1.65;
+
+    a {
+        color: var(--accent-color);
+        text-underline-offset: 2px;
+    }
 }
 
 .tool-embed {
     overflow: hidden;
     border-radius: 8px;
-    border: 1px solid var(--border-color);
     background: #0a0a0a;
 
     iframe {

--- a/index.html
+++ b/index.html
@@ -5,15 +5,10 @@ no_frame: true
 ---
 
 <div class="home-shell">
-    <section class="hero-section text-center section-panel">
-        <p class="section-kicker">PRIVATE TOOLKIT</p>
-        <h1>私人使用工具集</h1>
-        <p class="hero-subtitle">仅用于个人效率与创作场景，不对外提供在线服务。</p>
-    </section>
-
     <section id="tools" class="features-section section-panel">
         <div class="section-head">
-            <h2>🧰 工具列表</h2>
+            <p class="section-kicker">PRIVATE TOOLKIT</p>
+            <h1>私人使用工具集</h1>
             <p class="text-muted">两个常用入口，直接打开使用。</p>
         </div>
 
@@ -21,133 +16,14 @@ no_frame: true
             <article class="tool-card">
                 <h3>✨ 提示词生成器</h3>
                 <p>快速组织输入信息，生成结构化提示词，用于日常创作与 AI 协作。</p>
-                <p class="meta">最近更新：2026-04-22</p>
                 <a href="{{ '/prompt-generator/' | relative_url }}" class="btn">打开工具</a>
             </article>
 
             <article class="tool-card">
                 <h3>🌄 全景 Viewer</h3>
                 <p>用于本地查看和浏览全景素材，方便筛选、对比和快速预览。</p>
-                <p class="meta">最近更新：2026-04-22</p>
                 <a href="{{ '/panorama-viewer/' | relative_url }}" class="btn">打开工具</a>
             </article>
         </div>
     </section>
-
-    <section class="home-gallery section-panel">
-        <div class="section-head">
-            <h2>🖼️ 首页配图素材</h2>
-            <p class="text-muted">统一暗色 + 复古像素氛围，可直接用于首页横幅、卡片封面或文章头图。</p>
-        </div>
-
-        <div class="grid grid--3-col">
-            <article class="media-card">
-                <img src="{{ '/assets/images/homepage/scene-cyber-grid.svg' | relative_url }}" alt="赛博网格风格背景图">
-                <p>赛博网格 + 光晕中心，适合作为 Hero Banner。</p>
-            </article>
-
-            <article class="media-card">
-                <img src="{{ '/assets/images/homepage/scene-terminal-city.svg' | relative_url }}" alt="终端城市风格背景图">
-                <p>极简线框城市夜景，适合工具卡片封面。</p>
-            </article>
-
-            <article class="media-card">
-                <img src="{{ '/assets/images/homepage/scene-mountain-scanline.svg' | relative_url }}" alt="山脉扫描线风格背景图">
-                <p>扫描线山脉构图，适合文章列表视觉分隔。</p>
-            </article>
-        </div>
-    </section>
-
-    <section class="flag-section section-panel">
-        <div class="section-head">
-            <h2>🚩 飘荡的小红旗</h2>
-            <p class="text-muted">使用 Three.js 实现的轻量动态效果。</p>
-        </div>
-        <div id="floating-flag"></div>
-    </section>
 </div>
-
-<script type="module">
-    import * as THREE from 'https://unpkg.com/three@0.165.0/build/three.module.js';
-
-    const container = document.getElementById('floating-flag');
-
-    if (container) {
-        const scene = new THREE.Scene();
-        const camera = new THREE.PerspectiveCamera(45, container.clientWidth / container.clientHeight, 0.1, 100);
-        camera.position.set(0.5, 0.35, 2.2);
-
-        const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        renderer.setSize(container.clientWidth, container.clientHeight);
-        container.appendChild(renderer.domElement);
-
-        scene.add(new THREE.AmbientLight(0xffffff, 0.7));
-        const keyLight = new THREE.DirectionalLight(0xffffff, 1.0);
-        keyLight.position.set(2, 2, 2);
-        scene.add(keyLight);
-
-        const pole = new THREE.Mesh(
-            new THREE.CylinderGeometry(0.015, 0.015, 1.1, 16),
-            new THREE.MeshStandardMaterial({ color: 0xb0b0b0, metalness: 0.6, roughness: 0.35 })
-        );
-        pole.position.set(-0.8, 0, 0);
-        scene.add(pole);
-
-        const flagWidth = 1.15;
-        const flagHeight = 0.68;
-        const widthSegments = 36;
-        const heightSegments = 18;
-
-        const flagGeometry = new THREE.PlaneGeometry(flagWidth, flagHeight, widthSegments, heightSegments);
-        const basePositions = flagGeometry.attributes.position.array.slice();
-        const normals = flagGeometry.attributes.normal;
-
-        const flagMaterial = new THREE.MeshStandardMaterial({
-            color: 0xd90429,
-            side: THREE.DoubleSide,
-            metalness: 0.03,
-            roughness: 0.8
-        });
-
-        const flag = new THREE.Mesh(flagGeometry, flagMaterial);
-        flag.position.set(-0.2, 0.12, 0);
-        scene.add(flag);
-
-        function animate(time) {
-            const positions = flagGeometry.attributes.position.array;
-            const t = time * 0.001;
-
-            for (let i = 0; i < positions.length; i += 3) {
-                const x = basePositions[i];
-                const y = basePositions[i + 1];
-
-                const distanceFromPole = (x + flagWidth / 2) / flagWidth;
-                const waveAmp = 0.02 + distanceFromPole * 0.1;
-
-                positions[i + 2] = Math.sin(7 * distanceFromPole - t * 2.8 + y * 3.6) * waveAmp;
-                positions[i + 1] = y + Math.sin(4 * distanceFromPole + t * 2.1) * 0.01;
-            }
-
-            flagGeometry.attributes.position.needsUpdate = true;
-            flagGeometry.computeVertexNormals();
-            normals.needsUpdate = true;
-
-            flag.rotation.y = Math.sin(t * 0.8) * 0.08;
-            flag.rotation.x = Math.sin(t * 0.5) * 0.03;
-
-            renderer.render(scene, camera);
-            requestAnimationFrame(animate);
-        }
-
-        requestAnimationFrame(animate);
-
-        window.addEventListener('resize', () => {
-            const width = container.clientWidth;
-            const height = container.clientHeight;
-            camera.aspect = width / height;
-            camera.updateProjectionMatrix();
-            renderer.setSize(width, height);
-        });
-    }
-</script>

--- a/panorama-viewer.md
+++ b/panorama-viewer.md
@@ -7,14 +7,8 @@ no_frame: true
 ---
 
 <section class="tool-page">
-  <div class="tool-page__intro tool-page__intro--split">
-    <p class="tool-page__note">
-      使用说明：优先为手机端手势操作优化。可先点按钮进入全屏查看器，也可直接在下方嵌入窗口上传全景图（建议 2:1 比例）。
-    </p>
-
-    <a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener" class="btn">
-      打开全屏全景 Viewer
-    </a>
+  <div class="tool-page__intro">
+    <p class="tool-page__note">上传图片后可直接拖拽查看；如需独立窗口，可在<a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener">新标签页打开</a>。</p>
   </div>
 
   <div class="tool-embed tool-embed--tall">

--- a/prompt-generator.html
+++ b/prompt-generator.html
@@ -7,12 +7,6 @@ no_frame: true
 ---
 
 <section class="tool-page">
-  <div class="tool-page__intro">
-    <p class="tool-page__note">
-      已按手机端优先重排：单手区可点按、按钮更大、内容区更聚焦。
-    </p>
-  </div>
-
   <div class="tool-embed">
     <iframe
       src="{{ '/prompt-generator-app.html' | relative_url }}"


### PR DESCRIPTION
### Motivation
- 根据“少即是多”原则，移除首页视觉噪音并将页面视觉层级收敛为最多一层边框。
- 提升工具页聚焦性：只保留与生成/查看直接相关的内容，删除无效或次要控件（如小红旗、冗余说明、全屏按钮）。

### Description
- 从 `index.html` 中删除首页配图素材区和 Three.js 小红旗模块，并将页面标题/kicker 简化为工具列表头部显示。
- 从 `prompt-generator.html` 中移除非必要的说明区，只保留嵌入的生成器 `iframe`。 
- 从 `panorama-viewer.md` 中移除“打开全屏全景 Viewer”按钮，改为文内轻量链接并保留嵌入查看区域。 
- 在样式文件 `_sass/components/_terminal.scss` 中去掉多处内层描边（去除 `section-panel`、`tool-card`、`tool-embed`、`tool-page__intro` 的内层边框），并为 `tool-page__note` 添加链接样式以保持可读性。 

### Testing
- 运行 `bundle exec jekyll build` 失败，错误为仓库内缺少 `Gemfile` / `.bundle`，无法在当前环境构建网站（失败）。
- 运行 `jekyll build` 也失败，因运行环境未安装 `jekyll` 命令（失败）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb1ea8ab48328beeb435def8fec86)