### PR TITLE
style: remove main content border and compact footer into single line

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -3,16 +3,10 @@
 
 .card {
     background: var(--surface-color);
-    border: 1px solid var(--border-color);
+    border: none;
     border-radius: 2px;
     padding: 1.5rem;
     box-shadow: none;
-    transition: border-color 0.2s ease;
-
-    &:hover {
-        border-color: #2f2f2f;
-    }
-
     h1, h2, h3, h4, h5, h6 {
         color: var(--primary-color);
         margin-bottom: 0.75rem;

--- a/_sass/layout/_footer.scss
+++ b/_sass/layout/_footer.scss
@@ -1,10 +1,10 @@
 // Footer Layout - Minimalist Footer
-// Simple, clean footer design
+// Single-line compact footer design
 
 .site-footer {
     background: var(--surface-color);
     border-top: 1px solid var(--border-color);
-    padding: 2rem 0 1rem;
+    padding: 0.65rem 0;
     margin-top: auto;
 }
 
@@ -12,21 +12,20 @@
     max-width: 1200px;
     margin: 0 auto;
     padding: 0 1rem;
-    text-align: center;
-}
-
-.footer-info {
     display: flex;
     justify-content: center;
     align-items: center;
-    flex-wrap: wrap;
-    gap: 2rem;
-    margin-bottom: 1rem;
-    
-    @media (max-width: $mobile) {
-        flex-direction: column;
-        gap: 0.5rem;
-    }
+    gap: 1rem;
+    text-align: center;
+    white-space: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
+}
+
+.footer-info {
+    display: inline-flex;
+    align-items: center;
+    gap: 1rem;
 }
 
 .footer-status {
@@ -34,15 +33,15 @@
     font-size: 0.72rem;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    
+    gap: 0.45rem;
+
     &::before {
         content: "•";
         color: var(--accent-color);
     }
-    
+
     &:first-child::before {
         display: none;
     }
@@ -51,6 +50,28 @@
 .footer-copyright {
     color: var(--text-muted);
     font-size: 0.75rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border-color);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+
+    &::before {
+        content: "|";
+        color: var(--border-color);
+    }
+}
+
+@media (max-width: $mobile) {
+    .site-footer {
+        padding: 0.55rem 0;
+    }
+
+    .footer-content {
+        justify-content: flex-start;
+        gap: 0.75rem;
+    }
+
+    .footer-info,
+    .footer-copyright {
+        font-size: 0.68rem;
+    }
 }


### PR DESCRIPTION
### Motivation
- Make the main content area appear borderless by removing the `.card` border so pages look cleaner and match the requested “no border” appearance.
- Compress the footer into a single-line, inline layout to satisfy the requirement “footer compressed into one line” while preserving readability on small screens.

### Description
- Removed the border and hover border transition from `.card` in `_sass/components/_terminal.scss` by changing `border: 1px solid var(--border-color);` to `border: none;` and removing the hover transition rules.
- Reworked `_sass/layout/_footer.scss` to reduce vertical padding, make `.footer-content` a single-line `flex` container, and use `inline-flex` for `.footer-info` and `.footer-status` so footer items render on one line with a visual separator for the copyright.
- Added `white-space: nowrap`, `overflow-x: auto`, and tighter gaps to allow horizontal scrolling on very narrow viewports instead of wrapping, and added mobile-specific spacing adjustments under a `@media (max-width: $mobile)` block.

### Testing
- Ran `git status` to confirm changed files are staged and committed successfully (files modified: `_sass/components/_terminal.scss` and `_sass/layout/_footer.scss`).
- Attempted `bundle exec jekyll build` and it failed due to a missing `Gemfile` in the repository, so a local site build could not be executed in this environment.
- Attempted `jekyll build` and it failed because the `jekyll` CLI is not installed in the execution environment, so no automated site build was produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbfb4fc60832896c49c1a1df7d8e5)