### PR TITLE
style: 去除主内容区外框并精简页脚以避免滚动条

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,10 +1,5 @@
 <footer class="site-footer">
     <div class="footer-content">
-        <div class="footer-info">
-            <span class="footer-status">博客就绪</span>
-            <span class="footer-status">{{ site.time | date: "%Y" }} 年</span>
-            <span class="footer-status">持续更新中</span>
-        </div>
         <div class="footer-copyright">
             © {{ site.time | date: "%Y" }} {{ site.author | default: "博客作者" }}. 保留所有权利。
         </div>

--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -86,14 +86,14 @@
 }
 
 .section-panel {
-    background: linear-gradient(180deg, rgba(17, 17, 17, 0.94), rgba(17, 17, 17, 0.72));
-    border-radius: 10px;
-    padding: 1rem;
+    background: transparent;
+    border-radius: 0;
+    padding: 0;
 }
 
 @media (min-width: $tablet) {
     .section-panel {
-        padding: 1.4rem;
+        padding: 0;
     }
 }
 
@@ -187,10 +187,10 @@
 .tool-page {
     display: grid;
     gap: 0.75rem;
-    padding: 0.85rem;
-    background: linear-gradient(180deg, rgba(17, 17, 17, 0.94), rgba(17, 17, 17, 0.72));
-    border: 1px solid var(--border-color);
-    border-radius: 10px;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
 }
 
 .tool-page__intro {
@@ -243,7 +243,7 @@
 @media (min-width: $tablet) {
     .tool-page {
         gap: 0.9rem;
-        padding: 1.2rem;
+        padding: 0;
     }
 
     .tool-page__intro {

--- a/_sass/layout/_footer.scss
+++ b/_sass/layout/_footer.scss
@@ -15,49 +15,15 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 1rem;
     text-align: center;
-    white-space: nowrap;
-    overflow-x: auto;
-    scrollbar-width: thin;
-}
-
-.footer-info {
-    display: inline-flex;
-    align-items: center;
-    gap: 1rem;
-}
-
-.footer-status {
-    color: var(--text-muted);
-    font-size: 0.72rem;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-
-    &::before {
-        content: "•";
-        color: var(--accent-color);
-    }
-
-    &:first-child::before {
-        display: none;
-    }
+    overflow: hidden;
 }
 
 .footer-copyright {
     color: var(--text-muted);
     font-size: 0.75rem;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-
-    &::before {
-        content: "|";
-        color: var(--border-color);
-    }
+    white-space: normal;
+    line-height: 1.4;
 }
 
 @media (max-width: $mobile) {
@@ -66,12 +32,6 @@
     }
 
     .footer-content {
-        justify-content: flex-start;
-        gap: 0.75rem;
-    }
-
-    .footer-info,
-    .footer-copyright {
-        font-size: 0.68rem;
+        padding: 0 0.85rem;
     }
 }


### PR DESCRIPTION
### Motivation
- 使主内容区（首页与工具页）与页面背景融为一体，去除外层面板的边框/背景/圆角以获得更简洁的视觉效果。 
- 精简页脚内容并消除横向溢出，防止因长行或多余元素触发滚动条，提升移动端和小屏幕体验。 

### Description
- 将主容器样式从带背景和边框改为与背景一致：在 `_sass/components/_terminal.scss` 中将 `section-panel` 和 `tool-page` 的 `background` 改为 `transparent`，移除 `border`、`border-radius` 并将多余 `padding` 置为 `0`，以取消外层面板视觉。 
- 精简页脚模板：在 `_includes/footer.html` 中移除多余的状态项（如“博客就绪 / 年份 / 持续更新中”），仅保留版权信息。 
- 调整页脚样式以禁止溢出：在 `_sass/layout/_footer.scss` 中去掉横向滚动行为、取消 `white-space: nowrap` 并改为 `overflow: hidden` 与 `white-space: normal`，同时微调内边距与行高以避免触发滚动条。 

### Testing
- 尝试运行 `bundle exec jekyll build` 进行构建验证，但构建在此环境中失败，原因是仓库中缺少 `Gemfile`，因此无法在当前环境完成自动化构建测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc20c2158832881d2ad4d70e1b8c0)