### PR TITLE
移除全站头部与导航栏

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,8 +12,6 @@
 </head>
 <body>
     <div class="container">
-        {% include header.html %}
-
         <main class="main-content{% if page.no_frame %} main-content--full{% endif %}">
             {% if page.no_frame %}
                 {{ content }}


### PR DESCRIPTION
### Motivation
- 去掉全站 header 和导航栏以实现页面不显示顶部站点标题与菜单的需求。

### Description
- 从默认布局 `_layouts/default.html` 中移除了 `{% include header.html %}`，对应修改为删除包含 header 的三行。 
- 该变更只影响默认布局，主体内容渲染与 `{% include footer.html %}` 保持不变。

### Testing
- 尝试运行 `bundle exec jekyll build` 进行构建验证，但在此环境中因缺少 `Gemfile` 或 `.bundle` 导致构建失败。 
- 已打印并检查更新后的 `_layouts/default.html` 内容以确认 header include 已被移除。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc4aa9118832882b2443a3441ccd0)