### PR TITLE
Open standalone tool pages and add persistent “返回首页” links

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,13 @@ no_frame: true
             <article class="tool-card">
                 <h3>✨ 提示词生成器</h3>
                 <p>快速组织输入信息，生成结构化提示词，用于日常创作与 AI 协作。</p>
-                <a href="{{ '/prompt-generator-app.html' | relative_url }}" class="btn">打开工具</a>
+                <a href="{{ '/prompt-generator/' | relative_url }}" class="btn">打开工具</a>
             </article>
 
             <article class="tool-card">
                 <h3>🌄 全景 Viewer</h3>
                 <p>用于本地查看和浏览全景素材，方便筛选、对比和快速预览。</p>
-                <a href="{{ '/panorama-viewer.html' | relative_url }}" class="btn">打开工具</a>
+                <a href="{{ '/panorama-viewer/' | relative_url }}" class="btn">打开工具</a>
             </article>
         </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -11,13 +11,13 @@ no_frame: true
             <article class="tool-card">
                 <h3>✨ 提示词生成器</h3>
                 <p>快速组织输入信息，生成结构化提示词，用于日常创作与 AI 协作。</p>
-                <a href="{{ '/prompt-generator/' | relative_url }}" class="btn">打开工具</a>
+                <a href="{{ '/prompt-generator-app.html' | relative_url }}" class="btn">打开工具</a>
             </article>
 
             <article class="tool-card">
                 <h3>🌄 全景 Viewer</h3>
                 <p>用于本地查看和浏览全景素材，方便筛选、对比和快速预览。</p>
-                <a href="{{ '/panorama-viewer/' | relative_url }}" class="btn">打开工具</a>
+                <a href="{{ '/panorama-viewer.html' | relative_url }}" class="btn">打开工具</a>
             </article>
         </div>
     </section>

--- a/panorama-viewer.html
+++ b/panorama-viewer.html
@@ -44,6 +44,31 @@
       -webkit-backdrop-filter: blur(6px);
     }
 
+    .home-link {
+      position: fixed;
+      top: max(10px, env(safe-area-inset-top));
+      left: 10px;
+      z-index: 21;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 36px;
+      padding: 8px 12px;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      background: rgba(0, 0, 0, 0.62);
+      color: #fff;
+      font-size: 13px;
+      text-decoration: none;
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+
+    .home-link:hover {
+      border-color: rgba(255, 255, 255, 0.55);
+      background: rgba(0, 0, 0, 0.74);
+    }
+
     .upload-btn {
       display: flex;
       align-items: center;
@@ -116,6 +141,7 @@
 </head>
 <body>
   <div id="app"></div>
+  <a class="home-link" href="./">← 返回首页</a>
 
   <div class="toolbar">
     <label class="upload-btn" for="fileInput">上传全景图</label>

--- a/panorama-viewer.md
+++ b/panorama-viewer.md
@@ -7,8 +7,12 @@ no_frame: true
 ---
 
 <section class="tool-page">
-  <div class="tool-page__intro">
-    <p class="tool-page__note">上传图片后可直接拖拽查看；如需独立窗口，可在<a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener">新标签页打开</a>。</p>
+  <div class="tool-page__intro tool-page__intro--split">
+    <p class="tool-page__note">上传图片后可直接拖拽查看；如需更大视图可在新标签页打开。</p>
+    <p class="tool-page__note">
+      <a href="{{ '/' | relative_url }}">返回首页</a> ·
+      <a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener">新标签页打开</a>
+    </p>
   </div>
 
   <div class="tool-embed tool-embed--tall">

--- a/prompt-generator-app.html
+++ b/prompt-generator-app.html
@@ -49,6 +49,29 @@ body::before {
   pointer-events: none;
 }
 
+.home-link {
+  position: fixed;
+  top: max(12px, env(safe-area-inset-top));
+  left: 12px;
+  z-index: 20;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  border: 1px solid rgba(200,169,122,0.35);
+  background: rgba(17,17,17,0.82);
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.home-link:hover {
+  border-color: var(--accent);
+  color: #e0c59a;
+}
+
 .main { width: 100%; max-width: 780px; }
 
 .subject-bar {
@@ -287,6 +310,7 @@ body::before {
 </style>
 </head>
 <body>
+<a class="home-link" href="./">← 返回首页</a>
 
 <div class="main">
   <div class="subject-bar">

--- a/prompt-generator.html
+++ b/prompt-generator.html
@@ -7,6 +7,14 @@ no_frame: true
 ---
 
 <section class="tool-page">
+  <div class="tool-page__intro tool-page__intro--split">
+    <p class="tool-page__note">沉浸式使用提示词工具；可在新标签页打开独立版本。</p>
+    <p class="tool-page__note">
+      <a href="{{ '/' | relative_url }}">返回首页</a> ·
+      <a href="{{ '/prompt-generator-app.html' | relative_url }}" target="_blank" rel="noopener">新标签页打开</a>
+    </p>
+  </div>
+
   <div class="tool-embed">
     <iframe
       src="{{ '/prompt-generator-app.html' | relative_url }}"


### PR DESCRIPTION
### Motivation
- Tools opened from the homepage were landing inside framed pages that kept the site header/navigation visible, and when removing the header/navigation a clear return path to the homepage is required.

### Description
- Updated homepage tool cards to link directly to the standalone pages `prompt-generator-app.html` and `panorama-viewer.html` so users bypass the framed pages and avoid the site header interfering with the tool UI.
- Added a fixed `← 返回首页` link and accompanying CSS (`.home-link`) to `prompt-generator-app.html` so users can always return to the site root. 
- Added a fixed `← 返回首页` link and accompanying CSS (`.home-link`) to `panorama-viewer.html` so users can always return to the site root.
- Small markup updates in `index.html`, `prompt-generator-app.html`, and `panorama-viewer.html` to insert the links and styles.

### Testing
- Ran a diff check with `git diff` to verify the expected file changes, which showed the updated links and inserted home-link markup/CSS. 
- Attempted `bundle exec jekyll build` to validate site build, but it failed in this environment because no `Gemfile` is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc6fde3a0832882396a0f2f0ab155)