### PR TITLE
优化工具页交互：移除“返回首页/新标签页”，改为页内全屏与高度切换

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -223,6 +223,31 @@
     }
 }
 
+.tool-page__controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.tool-page__action {
+    appearance: none;
+    border: 1px solid var(--border-color);
+    background: transparent;
+    color: var(--secondary-color);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease;
+
+    &:hover {
+        border-color: var(--accent-color);
+        color: var(--accent-color);
+    }
+}
+
 .tool-embed {
     overflow: hidden;
     border-radius: 8px;
@@ -240,6 +265,10 @@
     min-height: min(82dvh, 840px);
 }
 
+.tool-embed--expanded iframe {
+    min-height: 100dvh;
+}
+
 @media (min-width: $tablet) {
     .tool-page {
         gap: 0.9rem;
@@ -253,6 +282,11 @@
     .tool-page__note {
         font-size: 0.875rem;
         line-height: 1.6;
+    }
+
+    .tool-page__action {
+        font-size: 0.75rem;
+        padding: 0.3rem 0.68rem;
     }
 
     .tool-embed iframe {

--- a/panorama-viewer.html
+++ b/panorama-viewer.html
@@ -44,31 +44,6 @@
       -webkit-backdrop-filter: blur(6px);
     }
 
-    .home-link {
-      position: fixed;
-      top: max(10px, env(safe-area-inset-top));
-      left: 10px;
-      z-index: 21;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 36px;
-      padding: 8px 12px;
-      border-radius: 8px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
-      background: rgba(0, 0, 0, 0.62);
-      color: #fff;
-      font-size: 13px;
-      text-decoration: none;
-      backdrop-filter: blur(6px);
-      -webkit-backdrop-filter: blur(6px);
-    }
-
-    .home-link:hover {
-      border-color: rgba(255, 255, 255, 0.55);
-      background: rgba(0, 0, 0, 0.74);
-    }
-
     .upload-btn {
       display: flex;
       align-items: center;
@@ -141,7 +116,6 @@
 </head>
 <body>
   <div id="app"></div>
-  <a class="home-link" href="./">← 返回首页</a>
 
   <div class="toolbar">
     <label class="upload-btn" for="fileInput">上传全景图</label>

--- a/panorama-viewer.md
+++ b/panorama-viewer.md
@@ -8,18 +8,52 @@ no_frame: true
 
 <section class="tool-page">
   <div class="tool-page__intro tool-page__intro--split">
-    <p class="tool-page__note">上传图片后可直接拖拽查看；如需更大视图可在新标签页打开。</p>
-    <p class="tool-page__note">
-      <a href="{{ '/' | relative_url }}">返回首页</a> ·
-      <a href="{{ '/panorama-viewer.html' | relative_url }}" target="_blank" rel="noopener">新标签页打开</a>
-    </p>
+    <p class="tool-page__note">上传图片后可直接拖拽查看：支持页面内全屏和高度切换，保持浏览上下文。</p>
+    <div class="tool-page__controls">
+      <button type="button" class="tool-page__action" data-height-target="panorama-viewer-embed">展开高度</button>
+      <button type="button" class="tool-page__action" data-fullscreen-target="panorama-viewer-frame">沉浸全屏</button>
+    </div>
   </div>
 
-  <div class="tool-embed tool-embed--tall">
+  <div class="tool-embed tool-embed--tall" id="panorama-viewer-embed">
     <iframe
+      id="panorama-viewer-frame"
       src="{{ '/panorama-viewer.html' | relative_url }}"
       title="全景 Viewer"
       loading="lazy">
     </iframe>
   </div>
 </section>
+
+<script>
+  (() => {
+    const embed = document.getElementById('panorama-viewer-embed');
+    const frame = document.getElementById('panorama-viewer-frame');
+    const heightButton = document.querySelector('[data-height-target="panorama-viewer-embed"]');
+    const fullscreenButton = document.querySelector('[data-fullscreen-target="panorama-viewer-frame"]');
+
+    if (heightButton && embed) {
+      heightButton.addEventListener('click', () => {
+        const expanded = embed.classList.toggle('tool-embed--expanded');
+        heightButton.textContent = expanded ? '恢复高度' : '展开高度';
+      });
+    }
+
+    if (fullscreenButton && frame) {
+      fullscreenButton.addEventListener('click', async () => {
+        try {
+          if (document.fullscreenElement) {
+            await document.exitFullscreen();
+            return;
+          }
+          await frame.requestFullscreen();
+        } catch (error) {
+          fullscreenButton.textContent = '当前设备不支持全屏';
+          window.setTimeout(() => {
+            fullscreenButton.textContent = '沉浸全屏';
+          }, 1800);
+        }
+      });
+    }
+  })();
+</script>

--- a/prompt-generator-app.html
+++ b/prompt-generator-app.html
@@ -49,29 +49,6 @@ body::before {
   pointer-events: none;
 }
 
-.home-link {
-  position: fixed;
-  top: max(12px, env(safe-area-inset-top));
-  left: 12px;
-  z-index: 20;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 12px;
-  border: 1px solid rgba(200,169,122,0.35);
-  background: rgba(17,17,17,0.82);
-  color: var(--accent);
-  text-decoration: none;
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  transition: border-color 0.15s, color 0.15s;
-}
-
-.home-link:hover {
-  border-color: var(--accent);
-  color: #e0c59a;
-}
-
 .main { width: 100%; max-width: 780px; }
 
 .subject-bar {
@@ -310,8 +287,6 @@ body::before {
 </style>
 </head>
 <body>
-<a class="home-link" href="./">← 返回首页</a>
-
 <div class="main">
   <div class="subject-bar">
     <span class="subject-label">FIXED</span>

--- a/prompt-generator.html
+++ b/prompt-generator.html
@@ -8,18 +8,52 @@ no_frame: true
 
 <section class="tool-page">
   <div class="tool-page__intro tool-page__intro--split">
-    <p class="tool-page__note">沉浸式使用提示词工具；可在新标签页打开独立版本。</p>
-    <p class="tool-page__note">
-      <a href="{{ '/' | relative_url }}">返回首页</a> ·
-      <a href="{{ '/prompt-generator-app.html' | relative_url }}" target="_blank" rel="noopener">新标签页打开</a>
-    </p>
+    <p class="tool-page__note">沉浸式使用提示词工具：支持一键全屏与自适应高度，无需跳转页面。</p>
+    <div class="tool-page__controls">
+      <button type="button" class="tool-page__action" data-height-target="prompt-generator-embed">展开高度</button>
+      <button type="button" class="tool-page__action" data-fullscreen-target="prompt-generator-frame">沉浸全屏</button>
+    </div>
   </div>
 
-  <div class="tool-embed">
+  <div class="tool-embed" id="prompt-generator-embed">
     <iframe
+      id="prompt-generator-frame"
       src="{{ '/prompt-generator-app.html' | relative_url }}"
       title="提示词生成器"
       loading="lazy">
     </iframe>
   </div>
 </section>
+
+<script>
+  (() => {
+    const embed = document.getElementById('prompt-generator-embed');
+    const frame = document.getElementById('prompt-generator-frame');
+    const heightButton = document.querySelector('[data-height-target="prompt-generator-embed"]');
+    const fullscreenButton = document.querySelector('[data-fullscreen-target="prompt-generator-frame"]');
+
+    if (heightButton && embed) {
+      heightButton.addEventListener('click', () => {
+        const expanded = embed.classList.toggle('tool-embed--expanded');
+        heightButton.textContent = expanded ? '恢复高度' : '展开高度';
+      });
+    }
+
+    if (fullscreenButton && frame) {
+      fullscreenButton.addEventListener('click', async () => {
+        try {
+          if (document.fullscreenElement) {
+            await document.exitFullscreen();
+            return;
+          }
+          await frame.requestFullscreen();
+        } catch (error) {
+          fullscreenButton.textContent = '当前设备不支持全屏';
+          window.setTimeout(() => {
+            fullscreenButton.textContent = '沉浸全屏';
+          }, 1800);
+        }
+      });
+    }
+  })();
+</script>


### PR DESCRIPTION
### Motivation
- 依据交互需求，移除工具页中会中断当前浏览上下文的“返回首页 / 新标签页打开”入口，提供更连续的页面内沉浸体验。
- 为移动端和桌面端提供一致的无跳转使用路径，减少浮层干扰并提升工具使用的专注度。

### Description
- 删除 `prompt-generator` 与 `panorama-viewer` 页面中的“返回首页 / 新标签页打开”链接，并移除两个独立工具页面中的固定浮动 `home-link` 控件（修改文件：`prompt-generator.html`、`panorama-viewer.md`、`prompt-generator-app.html`、`panorama-viewer.html`）。
- 在两处工具页增加页内控制：新增 `展开高度` 与 `沉浸全屏` 按钮并通过内联脚本调用 `tool-embed--expanded` 类与 iframe 全屏 API（实现位置：`prompt-generator.html` 与 `panorama-viewer.md` 的内联脚本）。
- 在样式层增加按钮样式与扩展高度支持：新增 `.tool-page__controls` / `.tool-page__action` 样式以及 `.tool-embed--expanded` 行为，修改文件：`_sass/components/_terminal.scss`。
- 在两个独立工具 HTML（`prompt-generator-app.html`、`panorama-viewer.html`）中清理了顶部返回浮层样式与 DOM 以减少视觉干扰并保持工具页面专注度。

### Testing
- 已用 `rg` 搜索确认原有文案与新标签行为已被移除，命令：`rg -n "返回首页|新标签|target=\"_blank\""`，搜索结果显示目标入口已去除（通过）。
- 在修改后对相关文件执行差异检查与内容查看（`git diff` / `sed`）以验证插入的控制按钮、脚本与样式位置正确（通过）。
- 尝试运行 `bundle exec jekyll build --quiet` 以做静态站点构建校验，但当前环境缺少 `Gemfile` / `.bundle` 目录导致构建无法执行（失败，环境限制）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecca15863c832894bee706275e49a7)