### PR TITLE
Add immersive home experience with entrance gate, view/sound controls, reveal and tilt interactions

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -333,3 +333,153 @@
         padding-top: 1rem;
     }
 }
+
+.experience-gate {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+    place-content: center;
+    text-align: center;
+    gap: 1rem;
+    padding: 1.2rem;
+    background: radial-gradient(circle at 20% 20%, rgba(200, 169, 122, 0.14), transparent 50%), var(--background-color);
+    transition: opacity 0.45s ease, visibility 0.45s ease;
+
+    &__since {
+        margin: 0;
+        color: var(--secondary-color);
+        letter-spacing: 0.26em;
+        text-transform: uppercase;
+        font-size: 0.7rem;
+    }
+
+    &__title {
+        margin: 0;
+        font-size: clamp(2rem, 7vw, 3.8rem);
+        letter-spacing: 0.18em;
+    }
+
+    &__enter {
+        justify-self: center;
+        min-width: 160px;
+        padding: 0.8rem 1rem;
+        border: 1px solid var(--accent-color);
+        background: transparent;
+        color: var(--accent-color);
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+        cursor: pointer;
+
+        &:hover {
+            background: rgba(200, 169, 122, 0.13);
+        }
+    }
+
+    &__tip {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.8rem;
+    }
+}
+
+body.js-experience .experience-gate {
+    display: grid;
+}
+
+.experience-controls {
+    position: fixed;
+    right: 0.85rem;
+    bottom: 0.85rem;
+    z-index: 80;
+    display: flex;
+    gap: 0.4rem;
+
+    &__btn {
+        border: 1px solid var(--border-color);
+        background: rgba(17, 17, 17, 0.88);
+        color: var(--secondary-color);
+        padding: 0.4rem 0.7rem;
+        font-size: 0.65rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        cursor: pointer;
+    }
+}
+
+.home-shell--immersive {
+    opacity: 1;
+    transform: none;
+    transition: opacity 0.35s ease, transform 0.35s ease;
+    padding-top: 0.2rem;
+}
+
+[data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+[data-reveal].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.section-panel--about {
+    border-top: 1px solid var(--border-color);
+    padding-top: 1rem;
+}
+
+.interaction-points {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.5rem;
+    color: var(--secondary-color);
+
+    li {
+        line-height: 1.65;
+    }
+}
+
+.tool-card[data-tilt] {
+    transition: transform 0.16s ease, border-color 0.2s ease;
+    transform-style: preserve-3d;
+
+    &:hover {
+        border-color: rgba(200, 169, 122, 0.5);
+    }
+}
+
+body.js-experience {
+    [data-reveal] {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+
+    .home-shell--immersive {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+}
+
+body.js-experience.experience-entered {
+    .experience-gate {
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+    }
+
+    .home-shell--immersive {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+body.js-experience.experience-view-mode {
+    --background-color: #08090f;
+    --surface-color: #0e1118;
+    --border-color: #2f3f5d;
+    --secondary-color: #9eaecf;
+    --accent-color: #7a9fc8;
+}

--- a/assets/js/home-experience.js
+++ b/assets/js/home-experience.js
@@ -1,0 +1,96 @@
+(() => {
+  document.body.classList.add('js-experience');
+
+  const gate = document.querySelector('[data-gate]');
+  const enterBtn = document.querySelector('[data-enter]');
+  const viewBtn = document.querySelector('[data-view-toggle]');
+  const soundBtn = document.querySelector('[data-sound-toggle]');
+  const revealItems = document.querySelectorAll('[data-reveal]');
+  const tiltCards = document.querySelectorAll('[data-tilt]');
+
+  if (!gate || !enterBtn) return;
+
+  const state = {
+    soundEnabled: false,
+    audioContext: null
+  };
+
+  const playUiBeep = (freq = 520) => {
+    if (!state.soundEnabled) return;
+
+    if (!state.audioContext) {
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      if (!Ctx) return;
+      state.audioContext = new Ctx();
+    }
+
+    const ctx = state.audioContext;
+    if (ctx.state === 'suspended') {
+      ctx.resume();
+    }
+
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+
+    oscillator.type = 'triangle';
+    oscillator.frequency.setValueAtTime(freq, ctx.currentTime);
+
+    gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.03, ctx.currentTime + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.16);
+
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+
+    oscillator.start();
+    oscillator.stop(ctx.currentTime + 0.18);
+  };
+
+  const unlockExperience = () => {
+    document.body.classList.add('experience-entered');
+    gate.setAttribute('aria-hidden', 'true');
+    playUiBeep(600);
+  };
+
+  enterBtn.addEventListener('click', unlockExperience);
+
+  viewBtn?.addEventListener('click', () => {
+    document.body.classList.toggle('experience-view-mode');
+    playUiBeep(430);
+  });
+
+  soundBtn?.addEventListener('click', () => {
+    state.soundEnabled = !state.soundEnabled;
+    soundBtn.textContent = state.soundEnabled ? 'Sound On' : 'Sound Off';
+    playUiBeep(state.soundEnabled ? 680 : 320);
+  });
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (!entry.isIntersecting) return;
+      entry.target.classList.add('is-visible');
+      playUiBeep(480);
+      observer.unobserve(entry.target);
+    });
+  }, { threshold: 0.22 });
+
+  revealItems.forEach((item) => observer.observe(item));
+
+  tiltCards.forEach((card) => {
+    card.addEventListener('mousemove', (event) => {
+      const rect = card.getBoundingClientRect();
+      const px = (event.clientX - rect.left) / rect.width;
+      const py = (event.clientY - rect.top) / rect.height;
+      const rx = (0.5 - py) * 7;
+      const ry = (px - 0.5) * 9;
+
+      card.style.transform = `perspective(700px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+    });
+
+    card.addEventListener('mouseleave', () => {
+      card.style.transform = '';
+    });
+
+    card.querySelector('.btn')?.addEventListener('mouseenter', () => playUiBeep(740));
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -4,21 +4,54 @@ title: "私人工具集 - 首页"
 no_frame: true
 ---
 
-<div class="home-shell">
-    <section id="tools" class="features-section section-panel">
+<div class="experience-gate" data-gate>
+    <p class="experience-gate__since">Since 2026</p>
+    <h1 class="experience-gate__title">私人工具集</h1>
+    <button class="experience-gate__enter" type="button" data-enter>Enter</button>
+    <p class="experience-gate__tip">点击 Enter 开始交互体验 · 可在右下角切换 View / Sound</p>
+</div>
+
+<div class="experience-controls" aria-label="Experience controls">
+    <button class="experience-controls__btn" type="button" data-view-toggle>View</button>
+    <button class="experience-controls__btn" type="button" data-sound-toggle>Sound Off</button>
+</div>
+
+<div class="home-shell home-shell--immersive" data-experience-root>
+    <section id="tools" class="features-section section-panel" data-reveal>
+        <header class="section-head">
+            <p class="section-kicker">01. TOOLS</p>
+            <h2>挑选一个入口，立即开始。</h2>
+            <p class="hero-subtitle">参考 y-n10 的入场流程与沉浸式滚动反馈，做了更轻量的交互化首页。</p>
+        </header>
 
         <div class="grid grid--auto-fit">
-            <article class="tool-card">
+            <article class="tool-card" data-tilt>
                 <h3>✨ 提示词生成器</h3>
                 <p>快速组织输入信息，生成结构化提示词，用于日常创作与 AI 协作。</p>
                 <a href="{{ '/prompt-generator/' | relative_url }}" class="btn">打开工具</a>
             </article>
 
-            <article class="tool-card">
+            <article class="tool-card" data-tilt>
                 <h3>🌄 全景 Viewer</h3>
                 <p>用于本地查看和浏览全景素材，方便筛选、对比和快速预览。</p>
                 <a href="{{ '/panorama-viewer/' | relative_url }}" class="btn">打开工具</a>
             </article>
         </div>
     </section>
+
+    <section class="section-panel section-panel--about" data-reveal>
+        <header class="section-head">
+            <p class="section-kicker">02. INTERACTION</p>
+            <h2>交互方式（复制版）</h2>
+        </header>
+
+        <ul class="interaction-points">
+            <li>入场 Gate：首次必须点击 Enter 才进入主内容。</li>
+            <li>分段显隐：滚动到可视区时内容渐显，保留“讲述感”。</li>
+            <li>视图切换：支持 View 模式切换，强化专注阅读。</li>
+            <li>声音开关：开启后在操作时提供轻微反馈音。</li>
+        </ul>
+    </section>
 </div>
+
+<script src="{{ '/assets/js/home-experience.js' | relative_url }}" defer></script>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,11 @@ no_frame: true
         <header class="section-head">
             <p class="section-kicker">01. TOOLS</p>
             <h2>挑选一个入口，立即开始。</h2>
-            <p class="hero-subtitle">参考 y-n10 的入场流程与沉浸式滚动反馈，做了更轻量的交互化首页。</p>
+            <p class="hero-subtitle">
+                参考
+                <a href="https://y-n10.com/" target="_blank" rel="noopener noreferrer">y-n10.com</a>
+                的入场流程与沉浸式滚动反馈，做了更轻量的交互化首页。
+            </p>
         </header>
 
         <div class="grid grid--auto-fit">
@@ -42,7 +46,7 @@ no_frame: true
     <section class="section-panel section-panel--about" data-reveal>
         <header class="section-head">
             <p class="section-kicker">02. INTERACTION</p>
-            <h2>交互方式（复制版）</h2>
+            <h2>交互方式</h2>
         </header>
 
         <ul class="interaction-points">


### PR DESCRIPTION
### Motivation

- Introduce a lightweight immersive homepage experience inspired by y-n10 to guide first-time visitors with an entrance gate and progressive reveals. 
- Provide optional view-mode styling and subtle audio feedback to enhance focus and interaction while keeping the content accessible.

### Description

- Added new styles in `_sass/components/_terminal.scss` to support `.experience-gate`, `.experience-controls`, reveal animations (`[data-reveal]`), tiltable `.tool-card[data-tilt]`, and a `experience-view-mode` color theme. 
- Added a new client script `assets/js/home-experience.js` that toggles the entrance gate, manages `View`/`Sound` buttons, plays short UI beeps via Web Audio when enabled, observes `[data-reveal]` elements with an `IntersectionObserver`, and implements mouse-based tilt interaction for cards. 
- Updated `index.html` to inject the entrance gate markup, experience controls, set `data-reveal` and `data-tilt` attributes on sections and cards, and include the new script with `defer`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccca9716483289834a376d43f40a3)