### PR TITLE
Refine homepage enter gate with scenic background and hidden Enter button

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -341,45 +341,64 @@
     z-index: 200;
     place-content: center;
     text-align: center;
-    gap: 1rem;
+    gap: 0.6rem;
     padding: 1.2rem;
-    background: radial-gradient(circle at 20% 20%, rgba(200, 169, 122, 0.14), transparent 50%), var(--background-color);
+    overflow: hidden;
+    background: #06070b;
     transition: opacity 0.45s ease, visibility 0.45s ease;
 
-    &__since {
-        margin: 0;
-        color: var(--secondary-color);
-        letter-spacing: 0.26em;
-        text-transform: uppercase;
-        font-size: 0.7rem;
+    &__bg {
+        position: absolute;
+        inset: 0;
+        background:
+            linear-gradient(180deg, rgba(6, 7, 11, 0.42), rgba(6, 7, 11, 0.86)),
+            radial-gradient(circle at 22% 18%, rgba(122, 159, 200, 0.24), transparent 45%),
+            url('/assets/images/homepage/scene-terminal-city.svg') center / cover no-repeat;
+        filter: saturate(1.15) contrast(1.05);
+        transform: scale(1.02);
     }
 
-    &__title {
-        margin: 0;
-        font-size: clamp(2rem, 7vw, 3.8rem);
-        letter-spacing: 0.18em;
+    &__enter,
+    &__tip {
+        position: relative;
+        z-index: 2;
     }
 
     &__enter {
-        justify-self: center;
-        min-width: 160px;
-        padding: 0.8rem 1rem;
-        border: 1px solid var(--accent-color);
-        background: transparent;
-        color: var(--accent-color);
-        letter-spacing: 0.24em;
+        position: absolute;
+        left: 64%;
+        top: 58%;
+        min-width: 92px;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid rgba(200, 169, 122, 0.42);
+        background: rgba(7, 8, 13, 0.45);
+        color: rgba(200, 169, 122, 0.8);
+        letter-spacing: 0.18em;
         text-transform: uppercase;
         cursor: pointer;
+        opacity: 0.34;
+        mix-blend-mode: screen;
+        backdrop-filter: blur(2px);
+        transition: opacity 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 
-        &:hover {
-            background: rgba(200, 169, 122, 0.13);
+        &:hover,
+        &:focus-visible {
+            opacity: 1;
+            border-color: var(--accent-color);
+            transform: translateY(-1px);
         }
     }
 
     &__tip {
         margin: 0;
-        color: var(--text-muted);
-        font-size: 0.8rem;
+        position: absolute;
+        left: 50%;
+        bottom: 1.2rem;
+        transform: translateX(-50%);
+        color: rgba(216, 223, 235, 0.78);
+        font-size: 0.72rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -5,10 +5,9 @@ no_frame: true
 ---
 
 <div class="experience-gate" data-gate>
-    <p class="experience-gate__since">Since 2026</p>
-    <h1 class="experience-gate__title">私人工具集</h1>
-    <button class="experience-gate__enter" type="button" data-enter>Enter</button>
-    <p class="experience-gate__tip">点击 Enter 开始交互体验 · 可在右下角切换 View / Sound</p>
+    <div class="experience-gate__bg" aria-hidden="true"></div>
+    <p class="experience-gate__tip">在画面里寻找入口</p>
+    <button class="experience-gate__enter" type="button" data-enter aria-label="Enter experience">Enter</button>
 </div>
 
 <div class="experience-controls" aria-label="Experience controls">
@@ -21,11 +20,6 @@ no_frame: true
         <header class="section-head">
             <p class="section-kicker">01. TOOLS</p>
             <h2>挑选一个入口，立即开始。</h2>
-            <p class="hero-subtitle">
-                参考
-                <a href="https://y-n10.com/" target="_blank" rel="noopener noreferrer">y-n10.com</a>
-                的入场流程与沉浸式滚动反馈，做了更轻量的交互化首页。
-            </p>
         </header>
 
         <div class="grid grid--auto-fit">
@@ -41,20 +35,6 @@ no_frame: true
                 <a href="{{ '/panorama-viewer/' | relative_url }}" class="btn">打开工具</a>
             </article>
         </div>
-    </section>
-
-    <section class="section-panel section-panel--about" data-reveal>
-        <header class="section-head">
-            <p class="section-kicker">02. INTERACTION</p>
-            <h2>交互方式</h2>
-        </header>
-
-        <ul class="interaction-points">
-            <li>入场 Gate：首次必须点击 Enter 才进入主内容。</li>
-            <li>分段显隐：滚动到可视区时内容渐显，保留“讲述感”。</li>
-            <li>视图切换：支持 View 模式切换，强化专注阅读。</li>
-            <li>声音开关：开启后在操作时提供轻微反馈音。</li>
-        </ul>
     </section>
 </div>
 


### PR DESCRIPTION
### Motivation
- Reduce first‑screen text density and make the entry feel more exploratory/game‑like by hiding the `Enter` control inside a scenic background. 
- Ensure users have a clearer, atmospheric cue to discover the entry rather than a heavy explanatory landing screen.

### Description
- Simplified the gate markup in `index.html` by replacing the large title block with a background layer (`.experience-gate__bg`), a short tip and the `Enter` button with an `aria-label` for accessibility. 
- Removed the extra “INTERACTION” explanation block and the hero subtitle so the tools area appears faster after entry. 
- Reworked `_sass/components/_terminal.scss` to add the full‑screen scene background (uses `scene-terminal-city.svg` with gradient overlays), reduce gap/spacing, and set `overflow: hidden` for the gate. 
- Restyled the `Enter` button and tip: the button is now positioned inside the scene with low opacity, `mix-blend-mode`, `backdrop-filter` and hover/focus styles to make it feel partially hidden and more discoverable on interaction. 

### Testing
- Ran `git status --short` to verify changed files were staged and committed successfully. 
- Attempted `bundle exec jekyll build`, which could not run in this environment due to a missing `Gemfile`/`.bundle`, so a local Jekyll build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd2839ecc83288b4957f44efa4997)