### PR TITLE
feat(home): redesign entry scene and add left sidebar tool nav

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -344,61 +344,71 @@
     gap: 0.6rem;
     padding: 1.2rem;
     overflow: hidden;
-    background: #06070b;
+    background: #545960;
     transition: opacity 0.45s ease, visibility 0.45s ease;
 
     &__bg {
         position: absolute;
         inset: 0;
         background:
-            linear-gradient(180deg, rgba(6, 7, 11, 0.42), rgba(6, 7, 11, 0.86)),
-            radial-gradient(circle at 22% 18%, rgba(122, 159, 200, 0.24), transparent 45%),
+            linear-gradient(180deg, rgba(46, 51, 59, 0.52), rgba(36, 41, 47, 0.88)),
+            radial-gradient(circle at 30% 20%, rgba(205, 212, 224, 0.16), transparent 52%),
+            radial-gradient(circle at 70% 68%, rgba(150, 158, 173, 0.2), transparent 48%),
             url('/assets/images/homepage/scene-terminal-city.svg') center / cover no-repeat;
-        filter: saturate(1.15) contrast(1.05);
+        filter: grayscale(0.95) saturate(0.55) blur(1px) contrast(0.92);
         transform: scale(1.02);
     }
 
-    &__enter,
-    &__tip {
+    &__enter {
         position: relative;
         z-index: 2;
-    }
-
-    &__enter {
         position: absolute;
-        left: 64%;
-        top: 58%;
-        min-width: 92px;
-        padding: 0.5rem 0.75rem;
-        border: 1px solid rgba(200, 169, 122, 0.42);
-        background: rgba(7, 8, 13, 0.45);
-        color: rgba(200, 169, 122, 0.8);
-        letter-spacing: 0.18em;
-        text-transform: uppercase;
+        right: 8vw;
+        bottom: 6vh;
+        width: clamp(74px, 8vw, 110px);
+        height: clamp(128px, 18vh, 178px);
+        border: 1px solid rgba(195, 171, 128, 0.46);
+        border-radius: 4px 4px 2px 2px;
+        background:
+            linear-gradient(180deg, rgba(50, 38, 26, 0.82), rgba(33, 23, 13, 0.95)),
+            repeating-linear-gradient(
+                90deg,
+                rgba(165, 133, 90, 0.09) 0 7px,
+                rgba(67, 49, 28, 0.1) 7px 14px
+            );
         cursor: pointer;
-        opacity: 0.34;
-        mix-blend-mode: screen;
+        opacity: 0.88;
+        box-shadow: 0 0 24px rgba(9, 8, 5, 0.45);
         backdrop-filter: blur(2px);
-        transition: opacity 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+        transition: opacity 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+
+        &::before {
+            content: "";
+            position: absolute;
+            inset: 8px 8px 20px;
+            border: 1px solid rgba(219, 197, 159, 0.22);
+            border-radius: 3px;
+        }
+
+        &::after {
+            content: "";
+            position: absolute;
+            right: 14px;
+            top: 54%;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: rgba(219, 197, 149, 0.84);
+            box-shadow: 0 0 8px rgba(219, 197, 149, 0.44);
+        }
 
         &:hover,
         &:focus-visible {
             opacity: 1;
             border-color: var(--accent-color);
             transform: translateY(-1px);
+            box-shadow: 0 0 28px rgba(26, 24, 15, 0.62);
         }
-    }
-
-    &__tip {
-        margin: 0;
-        position: absolute;
-        left: 50%;
-        bottom: 1.2rem;
-        transform: translateX(-50%);
-        color: rgba(216, 223, 235, 0.78);
-        font-size: 0.72rem;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
     }
 }
 
@@ -406,23 +416,107 @@ body.js-experience .experience-gate {
     display: grid;
 }
 
-.experience-controls {
+.home-sidebar-trigger {
+    display: none;
     position: fixed;
-    right: 0.85rem;
-    bottom: 0.85rem;
-    z-index: 80;
-    display: flex;
-    gap: 0.4rem;
+    left: 0.85rem;
+    top: 0.85rem;
+    z-index: 120;
+    border: 1px solid var(--border-color);
+    background: rgba(17, 17, 17, 0.88);
+    color: var(--secondary-color);
+    width: 36px;
+    height: 36px;
+    font-size: 1.15rem;
+    line-height: 1;
+    border-radius: 8px;
+    cursor: pointer;
+    place-items: center;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+}
 
-    &__btn {
-        border: 1px solid var(--border-color);
-        background: rgba(17, 17, 17, 0.88);
+.home-sidebar {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 110;
+    pointer-events: none;
+
+    &__backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(7, 9, 15, 0.5);
+        opacity: 0;
+        transition: opacity 0.25s ease;
+    }
+
+    &__panel {
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: min(280px, 78vw);
+        background: rgba(9, 12, 20, 0.94);
+        border-right: 1px solid var(--border-color);
+        padding: 1.15rem 0.95rem;
+        display: grid;
+        align-content: start;
+        gap: 0.8rem;
+        transform: translateX(-100%);
+        transition: transform 0.26s ease;
+    }
+
+    &__close {
+        justify-self: end;
+        border: 0;
+        background: transparent;
         color: var(--secondary-color);
-        padding: 0.4rem 0.7rem;
-        font-size: 0.65rem;
-        letter-spacing: 0.16em;
-        text-transform: uppercase;
+        font-size: 1.4rem;
         cursor: pointer;
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 0.8rem;
+        letter-spacing: 0.16em;
+        color: var(--secondary-color);
+        text-transform: uppercase;
+    }
+
+    &__link {
+        display: block;
+        border: 1px solid rgba(122, 159, 200, 0.3);
+        border-radius: 8px;
+        padding: 0.65rem 0.75rem;
+        color: var(--primary-color);
+        text-decoration: none;
+        transition: border-color 0.2s ease, transform 0.2s ease;
+
+        &:hover,
+        &:focus-visible {
+            border-color: var(--accent-color);
+            transform: translateX(2px);
+        }
+    }
+}
+
+body.js-experience .home-sidebar-trigger,
+body.js-experience .home-sidebar {
+    display: grid;
+}
+
+body.js-experience.sidebar-open {
+    .home-sidebar {
+        pointer-events: auto;
+    }
+
+    .home-sidebar__backdrop {
+        opacity: 1;
+    }
+
+    .home-sidebar__panel {
+        transform: translateX(0);
     }
 }
 
@@ -493,12 +587,17 @@ body.js-experience.experience-entered {
         opacity: 1;
         transform: none;
     }
+
+    .home-sidebar-trigger {
+        opacity: 1;
+        pointer-events: auto;
+        transform: none;
+    }
 }
 
-body.js-experience.experience-view-mode {
-    --background-color: #08090f;
-    --surface-color: #0e1118;
-    --border-color: #2f3f5d;
-    --secondary-color: #9eaecf;
-    --accent-color: #7a9fc8;
+@media (max-width: $tablet) {
+    .experience-gate__enter {
+        right: 12vw;
+        bottom: 7vh;
+    }
 }

--- a/assets/js/home-experience.js
+++ b/assets/js/home-experience.js
@@ -3,8 +3,9 @@
 
   const gate = document.querySelector('[data-gate]');
   const enterBtn = document.querySelector('[data-enter]');
-  const viewBtn = document.querySelector('[data-view-toggle]');
-  const soundBtn = document.querySelector('[data-sound-toggle]');
+  const sidebar = document.querySelector('[data-sidebar]');
+  const sidebarToggle = document.querySelector('[data-sidebar-toggle]');
+  const sidebarCloseTriggers = document.querySelectorAll('[data-sidebar-close], [data-sidebar-link]');
   const revealItems = document.querySelectorAll('[data-reveal]');
   const tiltCards = document.querySelectorAll('[data-tilt]');
 
@@ -49,20 +50,40 @@
   const unlockExperience = () => {
     document.body.classList.add('experience-entered');
     gate.setAttribute('aria-hidden', 'true');
+    sidebarToggle?.focus();
     playUiBeep(600);
+  };
+
+  const openSidebar = () => {
+    document.body.classList.add('sidebar-open');
+    sidebar?.setAttribute('aria-hidden', 'false');
+    playUiBeep(500);
+  };
+
+  const closeSidebar = () => {
+    document.body.classList.remove('sidebar-open');
+    sidebar?.setAttribute('aria-hidden', 'true');
+    playUiBeep(360);
   };
 
   enterBtn.addEventListener('click', unlockExperience);
 
-  viewBtn?.addEventListener('click', () => {
-    document.body.classList.toggle('experience-view-mode');
-    playUiBeep(430);
+  sidebarToggle?.addEventListener('click', () => {
+    if (document.body.classList.contains('sidebar-open')) {
+      closeSidebar();
+      return;
+    }
+    openSidebar();
   });
 
-  soundBtn?.addEventListener('click', () => {
-    state.soundEnabled = !state.soundEnabled;
-    soundBtn.textContent = state.soundEnabled ? 'Sound On' : 'Sound Off';
-    playUiBeep(state.soundEnabled ? 680 : 320);
+  sidebarCloseTriggers.forEach((trigger) => {
+    trigger.addEventListener('click', closeSidebar);
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && document.body.classList.contains('sidebar-open')) {
+      closeSidebar();
+    }
   });
 
   const observer = new IntersectionObserver((entries) => {

--- a/index.html
+++ b/index.html
@@ -6,14 +6,21 @@ no_frame: true
 
 <div class="experience-gate" data-gate>
     <div class="experience-gate__bg" aria-hidden="true"></div>
-    <p class="experience-gate__tip">在画面里寻找入口</p>
-    <button class="experience-gate__enter" type="button" data-enter aria-label="Enter experience">Enter</button>
+    <button class="experience-gate__enter" type="button" data-enter aria-label="Enter experience"></button>
 </div>
 
-<div class="experience-controls" aria-label="Experience controls">
-    <button class="experience-controls__btn" type="button" data-view-toggle>View</button>
-    <button class="experience-controls__btn" type="button" data-sound-toggle>Sound Off</button>
-</div>
+<button class="home-sidebar-trigger" type="button" aria-label="打开导航菜单" data-sidebar-toggle>…</button>
+
+<aside class="home-sidebar" data-sidebar aria-hidden="true">
+    <div class="home-sidebar__backdrop" data-sidebar-close></div>
+    <nav class="home-sidebar__panel" aria-label="工具导航">
+        <button class="home-sidebar__close" type="button" aria-label="关闭导航菜单" data-sidebar-close>×</button>
+        <p class="home-sidebar__title">工具模块</p>
+        <a href="#tools" class="home-sidebar__link" data-sidebar-link>进入工具区</a>
+        <a href="{{ '/prompt-generator/' | relative_url }}" class="home-sidebar__link" data-sidebar-link>提示词生成器</a>
+        <a href="{{ '/panorama-viewer/' | relative_url }}" class="home-sidebar__link" data-sidebar-link>全景 Viewer</a>
+    </nav>
+</aside>
 
 <div class="home-shell home-shell--immersive" data-experience-root>
     <section id="tools" class="features-section section-panel" data-reveal>


### PR DESCRIPTION
### Motivation
- Implement a “no-text” entry gate with a grey, foggy background and a door-like hotspot in the lower-right to match the requested visual treatment. 
- Provide quick access to the tools area via a left-side off-canvas navigation opened from a top-left ellipsis trigger so users can open the tool modules after entering.

### Description
- Updated homepage markup in `index.html` to remove visible entry text, make the enter button empty, add a top-left ellipsis trigger (`…`) and an off-canvas left sidebar with links to the `#tools` section, `prompt-generator`, and `panorama-viewer`.
- Added sidebar interaction wiring to `assets/js/home-experience.js` including `openSidebar`, `closeSidebar`, backdrop/link/close-button handlers, `Esc` key closing, and focus handling after unlock.
- Restyled the entry scene in `_sass/components/_terminal.scss` to a desaturated/grey fog background and redesigned the enter hotspot as a door-like element anchored bottom-right, plus added styles for the sidebar trigger, backdrop, panel, and open/close transitions.
- Removed the previous floating controls (`View` / `Sound`) from the homepage UI and adapted scripts/styles to the new sidebar-driven navigation.

### Testing
- Attempted a static build with `bundle exec jekyll build`, but it failed in this environment because the repository does not include a `Gemfile` / `.bundle`, so a full Jekyll build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecd5b84d408328bb0536fe88b935cf)