### PR TITLE
重构首页交互流程并还原参考图风格

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -334,107 +334,148 @@
     }
 }
 
+
 .experience-gate {
     display: none;
     position: fixed;
     inset: 0;
     z-index: 200;
-    place-content: center;
-    text-align: center;
-    gap: 0.6rem;
-    padding: 1.2rem;
     overflow: hidden;
-    background: #545960;
+    background: #111;
     transition: opacity 0.45s ease, visibility 0.45s ease;
 
     &__bg {
         position: absolute;
         inset: 0;
         background:
-            linear-gradient(180deg, rgba(46, 51, 59, 0.52), rgba(36, 41, 47, 0.88)),
-            radial-gradient(circle at 30% 20%, rgba(205, 212, 224, 0.16), transparent 52%),
-            radial-gradient(circle at 70% 68%, rgba(150, 158, 173, 0.2), transparent 48%),
-            url('/assets/images/homepage/scene-terminal-city.svg') center / cover no-repeat;
-        filter: grayscale(0.95) saturate(0.55) blur(1px) contrast(0.92);
+            linear-gradient(180deg, rgba(9, 9, 9, 0.25), rgba(9, 9, 9, 0.78)),
+            url('/assets/images/homepage/scene-mountain-scanline.svg') center / cover no-repeat;
+        filter: grayscale(1) contrast(1.03);
         transform: scale(1.02);
     }
 
-    &__enter {
+    &__grid {
+        position: absolute;
+        inset: 0;
+        background:
+            repeating-linear-gradient(90deg, rgba(242, 242, 242, 0.14) 0 1px, transparent 1px calc(100% / 6)),
+            repeating-linear-gradient(0deg, rgba(242, 242, 242, 0.12) 0 1px, transparent 1px 60px);
+    }
+
+    &__content {
         position: relative;
         z-index: 2;
+        height: 100%;
+        width: min(620px, 100%);
+        padding: 6.5rem clamp(1.2rem, 5vw, 2.6rem) 9rem;
+        display: grid;
+        align-content: start;
+        gap: 1rem;
+        color: #f2f2f2;
+    }
+
+    &__kicker {
+        margin: 0;
+        font-size: 0.95rem;
+        letter-spacing: 0.08em;
+        line-height: 1.3;
+    }
+
+    &__title {
+        margin: 1rem 0 0;
+        font-size: clamp(2rem, 5vw, 3.5rem);
+        line-height: 1.16;
+        letter-spacing: 0.01em;
+    }
+
+    &__hint {
+        margin: 0;
+        font-size: 0.95rem;
+        color: rgba(242, 242, 242, 0.82);
+        line-height: 1.7;
+    }
+
+    &__enter {
         position: absolute;
-        right: 8vw;
-        bottom: 6vh;
-        width: clamp(74px, 8vw, 110px);
-        height: clamp(128px, 18vh, 178px);
-        border: 1px solid rgba(195, 171, 128, 0.46);
-        border-radius: 4px 4px 2px 2px;
-        background:
-            linear-gradient(180deg, rgba(50, 38, 26, 0.82), rgba(33, 23, 13, 0.95)),
-            repeating-linear-gradient(
-                90deg,
-                rgba(165, 133, 90, 0.09) 0 7px,
-                rgba(67, 49, 28, 0.1) 7px 14px
-            );
+        right: clamp(1rem, 8vw, 4rem);
+        bottom: clamp(1.2rem, 7vh, 3.2rem);
+        width: clamp(82px, 19vw, 126px);
+        aspect-ratio: 1;
+        border: 2px solid #f2f2f2;
+        border-radius: 50%;
+        background: #000;
+        color: #f2f2f2;
+        z-index: 4;
         cursor: pointer;
-        opacity: 0.88;
-        box-shadow: 0 0 24px rgba(9, 8, 5, 0.45);
-        backdrop-filter: blur(2px);
-        transition: opacity 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
-
-        &::before {
-            content: "";
-            position: absolute;
-            inset: 8px 8px 20px;
-            border: 1px solid rgba(219, 197, 159, 0.22);
-            border-radius: 3px;
-        }
-
-        &::after {
-            content: "";
-            position: absolute;
-            right: 14px;
-            top: 54%;
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            background: rgba(219, 197, 149, 0.84);
-            box-shadow: 0 0 8px rgba(219, 197, 149, 0.44);
-        }
+        transition: transform 0.24s ease, box-shadow 0.24s ease;
+        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.18), 0 18px 30px rgba(0, 0, 0, 0.42);
 
         &:hover,
         &:focus-visible {
-            opacity: 1;
-            border-color: var(--accent-color);
-            transform: translateY(-1px);
-            box-shadow: 0 0 28px rgba(26, 24, 15, 0.62);
+            transform: scale(1.04);
+            box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2), 0 22px 35px rgba(0, 0, 0, 0.5);
         }
+    }
+
+    &__enter-ring {
+        position: absolute;
+        inset: -12px;
+        border: 1px solid rgba(230, 0, 18, 0.65);
+        border-radius: 50%;
+        animation: ringPulse 2s infinite ease-out;
+    }
+
+    &__enter-label {
+        position: absolute;
+        left: -88px;
+        bottom: 12px;
+        font-size: 0.75rem;
+        letter-spacing: 0.14em;
+        white-space: nowrap;
+        color: rgba(242, 242, 242, 0.86);
+    }
+}
+
+@keyframes ringPulse {
+    0% {
+        transform: scale(0.96);
+        opacity: 0.85;
+    }
+
+    70% {
+        transform: scale(1.06);
+        opacity: 0.3;
+    }
+
+    100% {
+        transform: scale(1.08);
+        opacity: 0;
     }
 }
 
 body.js-experience .experience-gate {
-    display: grid;
+    display: block;
 }
 
 .home-sidebar-trigger {
     display: none;
     position: fixed;
-    left: 0.85rem;
-    top: 0.85rem;
-    z-index: 120;
-    border: 1px solid var(--border-color);
-    background: rgba(17, 17, 17, 0.88);
-    color: var(--secondary-color);
-    width: 36px;
-    height: 36px;
-    font-size: 1.15rem;
+    left: 1rem;
+    top: 1rem;
+    z-index: 130;
+    border: 1px dashed rgba(242, 242, 242, 0.7);
+    background: rgba(17, 17, 17, 0.7);
+    color: #f2f2f2;
+    width: 42px;
+    height: 42px;
+    font-size: 1.35rem;
     line-height: 1;
-    border-radius: 8px;
+    border-radius: 999px;
     cursor: pointer;
     place-items: center;
     opacity: 0;
     pointer-events: none;
-    transform: translateY(-8px);
+    transform: translateY(-10px);
     transition: opacity 0.25s ease, transform 0.25s ease;
 }
 
@@ -442,62 +483,109 @@ body.js-experience .experience-gate {
     display: none;
     position: fixed;
     inset: 0;
-    z-index: 110;
+    z-index: 125;
     pointer-events: none;
 
     &__backdrop {
         position: absolute;
         inset: 0;
-        background: rgba(7, 9, 15, 0.5);
+        background: rgba(0, 0, 0, 0.45);
         opacity: 0;
-        transition: opacity 0.25s ease;
+        transition: opacity 0.26s ease;
     }
 
     &__panel {
         position: absolute;
         inset: 0 auto 0 0;
-        width: min(280px, 78vw);
-        background: rgba(9, 12, 20, 0.94);
-        border-right: 1px solid var(--border-color);
-        padding: 1.15rem 0.95rem;
+        width: min(340px, 84vw);
+        background:
+            linear-gradient(90deg, rgba(242, 242, 242, 0.96), rgba(242, 242, 242, 0.92)),
+            repeating-linear-gradient(90deg, rgba(17, 17, 17, 0.07) 0 1px, transparent 1px calc(100% / 6));
+        color: #111;
+        border-right: 1px solid rgba(17, 17, 17, 0.25);
+        padding: 1rem 1rem 1.2rem;
         display: grid;
         align-content: start;
-        gap: 0.8rem;
+        gap: 0.15rem;
         transform: translateX(-100%);
-        transition: transform 0.26s ease;
+        transition: transform 0.32s ease;
     }
 
     &__close {
         justify-self: end;
         border: 0;
         background: transparent;
-        color: var(--secondary-color);
+        color: #111;
         font-size: 1.4rem;
         cursor: pointer;
+        line-height: 1;
     }
 
-    &__title {
+    &__brand {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.75rem;
+        align-items: center;
+        padding: 0.2rem 0.2rem 0.8rem;
+        border-bottom: 1px solid rgba(17, 17, 17, 0.14);
+        margin-bottom: 0.25rem;
+    }
+
+    &__avatar {
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        background: linear-gradient(90deg, #111 0 50%, #e60012 50% 100%);
+        border: 1px solid rgba(17, 17, 17, 0.38);
+    }
+
+    &__brand-title {
         margin: 0;
         font-size: 0.8rem;
-        letter-spacing: 0.16em;
-        color: var(--secondary-color);
-        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 700;
     }
 
-    &__link {
-        display: block;
-        border: 1px solid rgba(122, 159, 200, 0.3);
-        border-radius: 8px;
-        padding: 0.65rem 0.75rem;
-        color: var(--primary-color);
+    &__brand-id {
+        margin: 0.15rem 0 0;
+        font-size: 0.7rem;
+        color: rgba(17, 17, 17, 0.7);
+    }
+
+    &__item {
+        display: grid;
+        grid-template-columns: 30px 1fr;
+        align-items: center;
         text-decoration: none;
-        transition: border-color 0.2s ease, transform 0.2s ease;
+        color: inherit;
+        gap: 0.8rem;
+        min-height: 50px;
+        border-bottom: 1px solid rgba(17, 17, 17, 0.08);
+        transition: background-color 0.2s ease;
+
+        strong {
+            display: block;
+            font-size: 0.95rem;
+            line-height: 1.2;
+        }
+
+        small {
+            display: block;
+            margin-top: 0.1rem;
+            color: rgba(17, 17, 17, 0.76);
+        }
 
         &:hover,
-        &:focus-visible {
-            border-color: var(--accent-color);
-            transform: translateX(2px);
+        &:focus-visible,
+        &.is-active {
+            background: rgba(230, 0, 18, 0.06);
         }
+    }
+
+    &__index {
+        font-size: 0.82rem;
+        letter-spacing: 0.04em;
+        color: rgba(17, 17, 17, 0.8);
     }
 }
 
@@ -521,46 +609,127 @@ body.js-experience.sidebar-open {
 }
 
 .home-shell--immersive {
-    opacity: 1;
-    transform: none;
-    transition: opacity 0.35s ease, transform 0.35s ease;
-    padding-top: 0.2rem;
+    position: relative;
+    min-height: 100vh;
+    padding-top: 0;
+    background:
+        linear-gradient(180deg, rgba(242, 242, 242, 0.96), rgba(242, 242, 242, 0.9)),
+        url('/assets/images/homepage/scene-mountain-scanline.svg') center bottom / cover no-repeat;
 }
 
-[data-reveal] {
-    opacity: 1;
-    transform: none;
-    transition: opacity 0.5s ease, transform 0.5s ease;
+.features-section.section-panel {
+    position: relative;
+    min-height: 100vh;
+    border: 0;
+    padding: clamp(5.5rem, 12vh, 8rem) clamp(1.1rem, 4vw, 3rem) 3rem;
+    background:
+        repeating-linear-gradient(90deg, rgba(17, 17, 17, 0.08) 0 1px, transparent 1px calc(100% / 6)),
+        repeating-linear-gradient(0deg, rgba(17, 17, 17, 0.06) 0 1px, transparent 1px 60px);
 }
 
-[data-reveal].is-visible {
-    opacity: 1;
-    transform: translateY(0);
-}
+.home-stage {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
 
-.section-panel--about {
-    border-top: 1px solid var(--border-color);
-    padding-top: 1rem;
-}
+    &__line {
+        position: absolute;
+        background: rgba(17, 17, 17, 0.58);
 
-.interaction-points {
-    margin: 0;
-    padding-left: 1.2rem;
-    display: grid;
-    gap: 0.5rem;
-    color: var(--secondary-color);
+        &--v {
+            left: clamp(1.1rem, 4vw, 3rem);
+            top: clamp(8rem, 20vh, 10rem);
+            width: 1px;
+            height: clamp(56px, 11vh, 94px);
+        }
 
-    li {
-        line-height: 1.65;
+        &--h {
+            left: clamp(1.1rem, 4vw, 3rem);
+            top: clamp(16rem, 39vh, 18rem);
+            width: clamp(32px, 6vw, 56px);
+            height: 1px;
+        }
     }
+
+    &__badge {
+        position: absolute;
+        right: clamp(1rem, 7vw, 3rem);
+        top: clamp(4.2rem, 12vh, 7rem);
+        font-size: clamp(2.2rem, 6vw, 4rem);
+        font-weight: 700;
+        color: #111;
+    }
+
+    &__label {
+        position: absolute;
+        right: clamp(1rem, 7vw, 3rem);
+        top: clamp(8rem, 19vh, 11.4rem);
+        font-size: 0.95rem;
+        letter-spacing: 0.04em;
+        line-height: 1.25;
+        color: rgba(17, 17, 17, 0.9);
+    }
+
+    &__block {
+        position: absolute;
+
+        &--blue {
+            left: clamp(0.8rem, 3vw, 2rem);
+            bottom: clamp(11rem, 22vh, 13rem);
+            width: clamp(40px, 6vw, 54px);
+            aspect-ratio: 1;
+            background: #0052ff;
+        }
+
+        &--red {
+            right: clamp(0.9rem, 6vw, 2.5rem);
+            bottom: clamp(8.5rem, 18vh, 11rem);
+            width: clamp(100px, 15vw, 160px);
+            aspect-ratio: 1;
+            background: rgba(230, 0, 18, 0.86);
+        }
+    }
+}
+
+.section-head--hero {
+    max-width: 540px;
+
+    .section-kicker {
+        margin-bottom: 0.6rem;
+        letter-spacing: 0.2em;
+        color: rgba(17, 17, 17, 0.72);
+    }
+
+    h2 {
+        font-size: clamp(1.8rem, 5.6vw, 3rem);
+        color: #111;
+        line-height: 1.2;
+    }
+
+    .section-desc {
+        margin-top: 1.3rem;
+        color: rgba(17, 17, 17, 0.72);
+        letter-spacing: 0.06em;
+    }
+}
+
+.grid.grid--auto-fit {
+    margin-top: clamp(14rem, 30vh, 19rem);
 }
 
 .tool-card[data-tilt] {
     transition: transform 0.16s ease, border-color 0.2s ease;
     transform-style: preserve-3d;
+    background: rgba(255, 255, 255, 0.6);
+    border-color: rgba(17, 17, 17, 0.25);
+
+    .btn {
+        border-color: rgba(17, 17, 17, 0.4);
+        color: #111;
+    }
 
     &:hover {
-        border-color: rgba(200, 169, 122, 0.5);
+        border-color: rgba(230, 0, 18, 0.45);
     }
 }
 
@@ -572,7 +741,13 @@ body.js-experience {
 
     .home-shell--immersive {
         opacity: 0;
-        transform: translateY(8px);
+        transform: scale(1.01);
+    }
+}
+
+body.js-experience.experience-transitioning {
+    .experience-gate {
+        animation: gateCollapse 0.62s ease forwards;
     }
 }
 
@@ -586,6 +761,7 @@ body.js-experience.experience-entered {
     .home-shell--immersive {
         opacity: 1;
         transform: none;
+        transition: opacity 0.36s ease, transform 0.36s ease;
     }
 
     .home-sidebar-trigger {
@@ -595,9 +771,39 @@ body.js-experience.experience-entered {
     }
 }
 
+@keyframes gateCollapse {
+    0% {
+        clip-path: circle(130% at 88% 90%);
+        opacity: 1;
+    }
+
+    100% {
+        clip-path: circle(8% at 88% 90%);
+        opacity: 0;
+    }
+}
+
 @media (max-width: $tablet) {
-    .experience-gate__enter {
-        right: 12vw;
-        bottom: 7vh;
+    .experience-gate {
+        &__content {
+            padding-top: 5.2rem;
+        }
+
+        &__title {
+            font-size: clamp(1.7rem, 9vw, 2.4rem);
+        }
+
+        &__enter-label {
+            left: -74px;
+            font-size: 0.68rem;
+        }
+    }
+
+    .grid.grid--auto-fit {
+        margin-top: 9.5rem;
+    }
+
+    .home-stage__badge {
+        font-size: clamp(2.2rem, 12vw, 3rem);
     }
 }

--- a/assets/js/home-experience.js
+++ b/assets/js/home-experience.js
@@ -13,10 +13,11 @@
 
   const state = {
     soundEnabled: false,
-    audioContext: null
+    audioContext: null,
+    hasEntered: false
   };
 
-  const playUiBeep = (freq = 520) => {
+  const playUiBeep = (freq = 520, duration = 0.14) => {
     if (!state.soundEnabled) return;
 
     if (!state.audioContext) {
@@ -37,42 +38,57 @@
     oscillator.frequency.setValueAtTime(freq, ctx.currentTime);
 
     gain.gain.setValueAtTime(0.0001, ctx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.03, ctx.currentTime + 0.02);
-    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.16);
+    gain.gain.exponentialRampToValueAtTime(0.04, ctx.currentTime + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + duration);
 
     oscillator.connect(gain);
     gain.connect(ctx.destination);
 
     oscillator.start();
-    oscillator.stop(ctx.currentTime + 0.18);
-  };
-
-  const unlockExperience = () => {
-    document.body.classList.add('experience-entered');
-    gate.setAttribute('aria-hidden', 'true');
-    sidebarToggle?.focus();
-    playUiBeep(600);
-  };
-
-  const openSidebar = () => {
-    document.body.classList.add('sidebar-open');
-    sidebar?.setAttribute('aria-hidden', 'false');
-    playUiBeep(500);
+    oscillator.stop(ctx.currentTime + duration + 0.02);
   };
 
   const closeSidebar = () => {
     document.body.classList.remove('sidebar-open');
     sidebar?.setAttribute('aria-hidden', 'true');
-    playUiBeep(360);
+    playUiBeep(360, 0.12);
+  };
+
+  const openSidebar = () => {
+    if (!state.hasEntered) return;
+    document.body.classList.add('sidebar-open');
+    sidebar?.setAttribute('aria-hidden', 'false');
+    playUiBeep(500, 0.14);
+  };
+
+  const unlockExperience = () => {
+    if (state.hasEntered) return;
+
+    state.hasEntered = true;
+    state.soundEnabled = true;
+
+    document.body.classList.add('experience-transitioning');
+    playUiBeep(640, 0.18);
+
+    window.setTimeout(() => {
+      document.body.classList.remove('experience-transitioning');
+      document.body.classList.add('experience-entered');
+      gate.setAttribute('aria-hidden', 'true');
+      sidebarToggle?.focus();
+      playUiBeep(540, 0.16);
+    }, 620);
   };
 
   enterBtn.addEventListener('click', unlockExperience);
 
   sidebarToggle?.addEventListener('click', () => {
+    if (!state.hasEntered) return;
+
     if (document.body.classList.contains('sidebar-open')) {
       closeSidebar();
       return;
     }
+
     openSidebar();
   });
 
@@ -84,16 +100,20 @@
     if (event.key === 'Escape' && document.body.classList.contains('sidebar-open')) {
       closeSidebar();
     }
+
+    if ((event.key === 'Enter' || event.key === ' ') && document.activeElement === enterBtn) {
+      unlockExperience();
+    }
   });
 
   const observer = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
       if (!entry.isIntersecting) return;
       entry.target.classList.add('is-visible');
-      playUiBeep(480);
+      playUiBeep(460, 0.12);
       observer.unobserve(entry.target);
     });
-  }, { threshold: 0.22 });
+  }, { threshold: 0.2 });
 
   revealItems.forEach((item) => observer.observe(item));
 
@@ -102,16 +122,16 @@
       const rect = card.getBoundingClientRect();
       const px = (event.clientX - rect.left) / rect.width;
       const py = (event.clientY - rect.top) / rect.height;
-      const rx = (0.5 - py) * 7;
+      const rx = (0.5 - py) * 8;
       const ry = (px - 0.5) * 9;
 
-      card.style.transform = `perspective(700px) rotateX(${rx}deg) rotateY(${ry}deg)`;
+      card.style.transform = `perspective(900px) rotateX(${rx}deg) rotateY(${ry}deg)`;
     });
 
     card.addEventListener('mouseleave', () => {
       card.style.transform = '';
     });
 
-    card.querySelector('.btn')?.addEventListener('mouseenter', () => playUiBeep(740));
+    card.querySelector('.btn')?.addEventListener('mouseenter', () => playUiBeep(720, 0.1));
   });
 })();

--- a/index.html
+++ b/index.html
@@ -4,29 +4,75 @@ title: "私人工具集 - 首页"
 no_frame: true
 ---
 
-<div class="experience-gate" data-gate>
+<div class="experience-gate" data-gate aria-label="进入体验页">
     <div class="experience-gate__bg" aria-hidden="true"></div>
-    <button class="experience-gate__enter" type="button" data-enter aria-label="Enter experience"></button>
+    <div class="experience-gate__grid" aria-hidden="true"></div>
+
+    <section class="experience-gate__content" aria-label="ENTER PAGE">
+        <p class="experience-gate__kicker">BEYOND<br>THE SURFACE</p>
+        <h1 class="experience-gate__title">有些出口，<br>是为了更好的探索。</h1>
+        <p class="experience-gate__hint">点击右下角的洞<br>开启旅程</p>
+    </section>
+
+    <button class="experience-gate__enter" type="button" data-enter aria-label="进入新页面">
+        <span class="experience-gate__enter-ring" aria-hidden="true"></span>
+        <span class="experience-gate__enter-label">SCROLL +</span>
+    </button>
 </div>
 
 <button class="home-sidebar-trigger" type="button" aria-label="打开导航菜单" data-sidebar-toggle>…</button>
 
 <aside class="home-sidebar" data-sidebar aria-hidden="true">
     <div class="home-sidebar__backdrop" data-sidebar-close></div>
-    <nav class="home-sidebar__panel" aria-label="工具导航">
+    <nav class="home-sidebar__panel" aria-label="探索导航">
         <button class="home-sidebar__close" type="button" aria-label="关闭导航菜单" data-sidebar-close>×</button>
-        <p class="home-sidebar__title">工具模块</p>
-        <a href="#tools" class="home-sidebar__link" data-sidebar-link>进入工具区</a>
-        <a href="{{ '/prompt-generator/' | relative_url }}" class="home-sidebar__link" data-sidebar-link>提示词生成器</a>
-        <a href="{{ '/panorama-viewer/' | relative_url }}" class="home-sidebar__link" data-sidebar-link>全景 Viewer</a>
+
+        <header class="home-sidebar__brand">
+            <span class="home-sidebar__avatar" aria-hidden="true"></span>
+            <div>
+                <p class="home-sidebar__brand-title">EXPLORER</p>
+                <p class="home-sidebar__brand-id">ID: 1024</p>
+            </div>
+        </header>
+
+        <a href="#tools" class="home-sidebar__item is-active" data-sidebar-link>
+            <span class="home-sidebar__index">01</span>
+            <span><strong>HOME</strong><small>首页</small></span>
+        </a>
+        <a href="{{ '/blog/' | relative_url }}" class="home-sidebar__item" data-sidebar-link>
+            <span class="home-sidebar__index">02</span>
+            <span><strong>STORIES</strong><small>故事</small></span>
+        </a>
+        <a href="{{ '/prompt-generator/' | relative_url }}" class="home-sidebar__item" data-sidebar-link>
+            <span class="home-sidebar__index">03</span>
+            <span><strong>COLLECTION</strong><small>提示词工具</small></span>
+        </a>
+        <a href="{{ '/panorama-viewer/' | relative_url }}" class="home-sidebar__item" data-sidebar-link>
+            <span class="home-sidebar__index">04</span>
+            <span><strong>NOTES</strong><small>全景 Viewer</small></span>
+        </a>
+        <a href="{{ '/about/' | relative_url }}" class="home-sidebar__item" data-sidebar-link>
+            <span class="home-sidebar__index">05</span>
+            <span><strong>ABOUT</strong><small>关于</small></span>
+        </a>
     </nav>
 </aside>
 
 <div class="home-shell home-shell--immersive" data-experience-root>
     <section id="tools" class="features-section section-panel" data-reveal>
-        <header class="section-head">
-            <p class="section-kicker">01. TOOLS</p>
-            <h2>挑选一个入口，立即开始。</h2>
+        <div class="home-stage" aria-hidden="true">
+            <span class="home-stage__line home-stage__line--v"></span>
+            <span class="home-stage__line home-stage__line--h"></span>
+            <span class="home-stage__badge">02</span>
+            <span class="home-stage__label">EXPLORE<br>THE WORLD</span>
+            <span class="home-stage__block home-stage__block--blue"></span>
+            <span class="home-stage__block home-stage__block--red"></span>
+        </div>
+
+        <header class="section-head section-head--hero">
+            <p class="section-kicker">002</p>
+            <h2>探索世界，<br>也探索自己。</h2>
+            <p class="section-desc">VIEW MORE →</p>
         </header>
 
         <div class="grid grid--auto-fit">


### PR DESCRIPTION
### Motivation
- 将首页重构为沉浸式体验页以贴合参考图的四段交互流程（入口页 → 过渡 → 主舞台 → 侧边导航），提升视觉层级和交互可发现性。
- 在可访问性与键盘交互层面完善入口与侧边栏行为，并保留并增强原有的 reveal/tilt 微交互与反馈音效触发时机。

### Description
- 调整页面结构：重写 `index.html`，新增 `experience-gate` 层（背景、网格、文案区、右下圆形入口与标签），并重排主舞台装饰（编号、标签、红/蓝色块）与侧边栏项为编号式导航（包含头像/品牌区）。
- 交互逻辑重构：替换并重写 `assets/js/home-experience.js`，引入 `hasEntered` 状态、`experience-transitioning` 过渡态、键盘 Enter/Space 触发入口、Esc 与遮罩关闭侧边栏，以及微交互音效时序与 IntersectionObserver 调整。
- 样式与动画更新：修改 `_sass/components/_terminal.scss`，实现黑白场景、6 列网格纹理、入口圆环脉冲 (`ringPulse`)、入口坍缩过渡动画 (`gateCollapse`)、侧边栏滑出样式与响应式适配，以及主舞台装饰性块与卡片样式调整。
- 提交与变更范围：本次变更影响 `index.html`、`assets/js/home-experience.js` 和 `_sass/components/_terminal.scss`，以便整体呈现参考图风格和交互流程。

### Testing
- 已运行 `git diff --check` 验证代码空白问题，结果通过（无问题）。
- 尝试运行 `bundle exec jekyll build` 进行本地构建时失败，原因是当前环境缺少 `Gemfile`/`.bundle`（命令输出为 `Could not locate Gemfile or .bundle/ directory`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecde167e148328bd87319c31c3f41b)