### PR TITLE
Fix hidden reveal sections after entering experience mode

### DIFF
--- a/_sass/components/_terminal.scss
+++ b/_sass/components/_terminal.scss
@@ -737,6 +737,12 @@ body.js-experience {
     [data-reveal] {
         opacity: 0;
         transform: translateY(16px);
+        transition: opacity 0.4s ease, transform 0.4s ease;
+    }
+
+    [data-reveal].is-visible {
+        opacity: 1;
+        transform: none;
     }
 
     .home-shell--immersive {


### PR DESCRIPTION
### Motivation
- Restore reveal content that became permanently hidden when `body.js-experience` was added because the matching `.is-visible` rule was removed, causing sections revealed by JS to remain transparent.

### Description
- In `_sass/components/_terminal.scss` add a `transition` to `[data-reveal]` and restore a `[data-reveal].is-visible` rule that sets `opacity: 1` and `transform: none`, aligning CSS with the `assets/js/home-experience.js` behavior.

### Testing
- Ran `git diff --check` which reported no issues; and attempted `bundle exec jekyll build` which failed in this environment due to a missing `Gemfile`/`.bundle` directory (expected for this repo setup).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece216c8f0832881e859d405f0ca02)